### PR TITLE
Defer instantiation of out-of-line methods. When an overload set is a…

### DIFF
--- a/clang/lib/Lex/PPLexerChange.cpp
+++ b/clang/lib/Lex/PPLexerChange.cpp
@@ -504,9 +504,11 @@ bool Preprocessor::HandleEndOfFile(Token &Result, bool isEndOfMacro) {
     if (!isEndOfMacro && CurPPLexer) {
       ExitedFID = CurPPLexer->getFileID();
 
-      assert(PredefinesFileID.isValid() &&
-             "HandleEndOfFile is called before PredefinesFileId is set");
-      ExitedFromPredefinesFile = (PredefinesFileID == ExitedFID);
+      if (getLangOpts().EnablePredefines) {
+        assert(PredefinesFileID.isValid() &&
+               "HandleEndOfFile is called before PredefinesFileId is set");
+        ExitedFromPredefinesFile = (PredefinesFileID == ExitedFID);
+      }
     }
 
     if (LeavingSubmodule) {

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -15080,6 +15080,14 @@ Sema::BuildCallToObjectOfClassType(Scope *S, Expr *Obj,
     break;
   }
   case OR_Ambiguous:
+    if (getLangOpts().LexicalTemplateInstantiation) {
+      for (auto it = CandidateSet.begin(); it != CandidateSet.end(); ++it) {
+        if (it->Viable) {
+          Best = it;
+          goto force;
+        }
+      }
+    }
     CandidateSet.NoteCandidates(
         PartialDiagnosticAt(Object.get()->getBeginLoc(),
                             PDiag(diag::err_ovl_ambiguous_object_call)
@@ -15098,6 +15106,7 @@ Sema::BuildCallToObjectOfClassType(Scope *S, Expr *Obj,
     break;
   }
 
+force:
   if (Best == CandidateSet.end())
     return true;
 

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -3876,7 +3876,12 @@ Sema::InstantiateClassMembers(SourceLocation PointOfInstantiation,
           // instantiated now, and its linkage might have changed.
           Consumer.HandleTopLevelDecl(DeclGroupRef(Function));
         } else if (TSK == TSK_ExplicitInstantiationDefinition) {
-          InstantiateFunctionDefinition(PointOfInstantiation, Function);
+          if (getLangOpts().LexicalTemplateInstantiation &&
+              Function->isOutOfLine()) {
+            PendingInstantiations.emplace_back(Function, PointOfInstantiation);
+          } else {
+            InstantiateFunctionDefinition(PointOfInstantiation, Function);
+          }
         } else if (TSK == TSK_ImplicitInstantiation) {
           PendingLocalImplicitInstantiations.push_back(
               std::make_pair(Function, PointOfInstantiation));


### PR DESCRIPTION
…mbiguous, choose the first thing.