### PR TITLE
Tweaks the definition of FunctionDecl and VarDecl ::isOutOfLine to no…

### DIFF
--- a/clang/lib/AST/Decl.cpp
+++ b/clang/lib/AST/Decl.cpp
@@ -2389,6 +2389,10 @@ bool VarDecl::isOutOfLine() const {
   if (!isStaticDataMember())
     return false;
 
+  if (getASTContext().getLangOpts().LexicalTemplateInstantiation) {
+    return false;
+  }
+
   // If this static data member was instantiated from a static data member of
   // a class template, check whether that static data member was defined
   // out-of-line.
@@ -4222,6 +4226,10 @@ SourceLocation FunctionDecl::getPointOfInstantiation() const {
 bool FunctionDecl::isOutOfLine() const {
   if (Decl::isOutOfLine())
     return true;
+
+  if (getASTContext().getLangOpts().LexicalTemplateInstantiation) {
+    return false;
+  }
 
   // If this function was instantiated from a member function of a
   // class template, check whether that member function was defined out-of-line.


### PR DESCRIPTION
…t go and discover if the primary thing is out-of-line, but to just focus on the current decl