### PR TITLE
[CT] Fixed inline regression by making `ctselect` a architecture capability instead of CPU feature

### DIFF
--- a/clang/lib/Basic/Targets/AArch64.cpp
+++ b/clang/lib/Basic/Targets/AArch64.cpp
@@ -798,6 +798,7 @@ bool AArch64TargetInfo::hasFeature(StringRef Feature) const {
       .Cases("ls64", "ls64_v", "ls64_accdata", HasLS64)
       .Case("wfxt", HasWFxT)
       .Case("rcpc3", HasRCPC3)
+      .Case("ctselect", true)
       .Default(false);
 }
 

--- a/clang/lib/Basic/Targets/ARM.cpp
+++ b/clang/lib/Basic/Targets/ARM.cpp
@@ -659,6 +659,7 @@ bool ARMTargetInfo::hasFeature(StringRef Feature) const {
       .Case("hwdiv", HWDiv & HWDivThumb)
       .Case("hwdiv-arm", HWDiv & HWDivARM)
       .Case("mve", hasMVE())
+      .Case("ctselect", true)
       .Default(false);
 }
 

--- a/clang/lib/Basic/Targets/X86.cpp
+++ b/clang/lib/Basic/Targets/X86.cpp
@@ -1330,6 +1330,7 @@ bool X86TargetInfo::hasFeature(StringRef Feature) const {
       .Case("cf", HasCF)
       .Case("zu", HasZU)
       .Case("branch-hint", HasBranchHint)
+      .Case("ctselect", true)
       .Default(false);
 }
 

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -2976,6 +2976,12 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     break;
 
   case Builtin::BI__builtin_ct_select: {
+    // check to see if the Arch supports it
+    if (!Context.getTargetInfo().hasFeature("ctselect")) {
+      return Diag(TheCall->getBeginLoc(), diag::err_builtin_target_unsupported)
+             << TheCall->getSourceRange();
+    }
+
     if (TheCall->getNumArgs() != 3) {
       // Simple argument count check without complex diagnostics
       if (TheCall->getNumArgs() < 3) {

--- a/llvm/lib/Target/X86/X86.td
+++ b/llvm/lib/Target/X86/X86.td
@@ -39,9 +39,6 @@ def FeatureNOPL    : SubtargetFeature<"nopl", "HasNOPL", "true",
 def FeatureCMOV    : SubtargetFeature<"cmov","HasCMOV", "true",
                                       "Enable conditional move instructions">;
 
-def FeatureCtSelect : SubtargetFeature<"ctselect", "HasCtSelect", "true",
-                                       "Enable feature to implement constant-time select">;
-
 def FeatureCX8     : SubtargetFeature<"cx8", "HasCX8", "true",
                                       "Support CMPXCHG8B instructions">;
 
@@ -827,9 +824,10 @@ include "X86SchedSapphireRapids.td"
 
 def ProcessorFeatures {
   // x86-64 micro-architecture levels: x86-64 and x86-64-v[234]
-  list<SubtargetFeature> X86_64V1Features = [
-    FeatureX87, FeatureCX8, FeatureCMOV, FeatureMMX, FeatureSSE2,
-    FeatureFXSR, FeatureNOPL, FeatureX86_64, FeatureCtSelect, 
+  list<SubtargetFeature> X86_64V1Features = [FeatureX87, FeatureCX8,
+                                             FeatureCMOV, FeatureMMX,
+                                             FeatureSSE2, FeatureFXSR,
+                                             FeatureNOPL, FeatureX86_64,
   ];
   list<SubtargetFeature> X86_64V1Tuning = [
     TuningMacroFusion,

--- a/llvm/lib/Target/X86/X86InstrPredicates.td
+++ b/llvm/lib/Target/X86/X86InstrPredicates.td
@@ -49,7 +49,6 @@ def HasZU        : Predicate<"Subtarget->hasZU()">;
 def HasCF        : Predicate<"Subtarget->hasCF()">;
 def HasCMOV      : Predicate<"Subtarget->canUseCMOV()">;
 def NoCMOV       : Predicate<"!Subtarget->canUseCMOV()">;
-def HasCtSelect  : Predicate<"Subtarget->hasCtSelect()">;
 def HasNOPL      : Predicate<"Subtarget->hasNOPL()">;
 def HasMMX       : Predicate<"Subtarget->hasMMX()">;
 def HasSSE1      : Predicate<"Subtarget->hasSSE1()">;


### PR DESCRIPTION
**Previous Issue:** https://github.com/trail-of-forks/llvm-project/issues/28

## Problem
Adding `FeatureCtSelect` as a CPU feature in X86.td caused an inlining regression. Functions with different `target-cpu` attributes (e.g., k8, nehalem, goldmont) were incorrectly considered incompatible for inlining, causing the test `Transforms/Inline/X86/inline-target-cpu-x86_64.ll` to fail.

## Root Cause
The inliner treats CPU features as compatibility barriers. When `FeatureCtSelect` was added to `X86_64V1Features`, functions compiled for specific CPUs (like k8) didn't have this feature, while generic x86-64 functions did, preventing inlining between them.

## Solution
- Removed `FeatureCtSelect` from X86.td
- Removed it from `X86_64V1Features` list
- Made ctselect an architecture capability (always returns true in `X86TargetInfo::hasFeature`)
- Added frontend check in SemaChecking.cpp to verify architecture support

## Impact
This change:
- Fixes the immediate regression in `inline-target-cpu-x86_64.ll`
- Prevents similar issues with CPU features affecting inlining decisions
- Maintains full ctselect functionality without the feature flag complexity

## Testing
- ✅ `inline-target-cpu-x86_64.ll` now passes
- ✅ ctselect intrinsic still generates correct code
- ✅ All related tests pass