### PR TITLE
Expand `ctselect` pseudo instruction for vector types in post RA expansion pass

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -24931,18 +24931,19 @@ static SDValue LowerSIGN_EXTEND_Mask(SDValue Op, const SDLoc &dl,
 }
 
 SDValue X86TargetLowering::LowerCTSELECT(SDValue Op, SelectionDAG &DAG) const {
-  SDValue Cond = Op.getOperand(0);
-  SDValue Op1 = Op.getOperand(1);
-  SDValue Op2 = Op.getOperand(2);
+  SDValue Cond = Op.getOperand(0); // condition
+  SDValue TrueOp = Op.getOperand(1);  // true_value
+  SDValue FalseOp = Op.getOperand(2); // false_value
   SDLoc DL(Op);
-  MVT VT = Op1.getSimpleValueType();
+  MVT VT = TrueOp.getSimpleValueType();
 
   // Handle soft float16 by converting to integer operations
   if (isSoftF16(VT, Subtarget)) {
     MVT NVT = VT.changeTypeToInteger();
-    return DAG.getBitcast(VT, DAG.getNode(ISD::CTSELECT, DL, NVT, Cond,
-                                          DAG.getBitcast(NVT, Op1),
-                                          DAG.getBitcast(NVT, Op2)));
+    SDValue CtSelect =
+        DAG.getNode(ISD::CTSELECT, DL, NVT, Cond, DAG.getBitcast(NVT, FalseOp),
+                    DAG.getBitcast(NVT, TrueOp));
+    return DAG.getBitcast(VT, CtSelect);
   }
 
   // Handle vector types
@@ -24950,15 +24951,14 @@ SDValue X86TargetLowering::LowerCTSELECT(SDValue Op, SelectionDAG &DAG) const {
     // Handle soft float16 vectors
     if (isSoftF16(VT, Subtarget)) {
       MVT NVT = VT.changeVectorElementTypeToInteger();
-      return DAG.getBitcast(VT, DAG.getNode(ISD::CTSELECT, DL, NVT, Cond,
-                                            DAG.getBitcast(NVT, Op1),
-                                            DAG.getBitcast(NVT, Op2)));
+      SDValue CtSelect = DAG.getNode(ISD::CTSELECT, DL, NVT, Cond,
+                                     DAG.getBitcast(NVT, FalseOp),
+                                     DAG.getBitcast(NVT, TrueOp));
+      return DAG.getBitcast(VT, CtSelect);
     }
 
     unsigned VectorWidth = VT.getSizeInBits();
     MVT EltVT = VT.getVectorElementType();
-    unsigned NumElts = VT.getVectorNumElements();
-
     // Check if we have the necessary SIMD support
     bool HasSSE = Subtarget.hasSSE1();
     bool HasAVX = Subtarget.hasAVX();
@@ -24978,22 +24978,12 @@ SDValue X86TargetLowering::LowerCTSELECT(SDValue Op, SelectionDAG &DAG) const {
 
     // Handle special cases for floating point vectors
     if (EltVT.isFloatingPoint()) {
-      // For AVX-512, use mask-based selection for better performance
-      if (HasAVX512 && VectorWidth == 512) {
-        // Convert condition to mask and use masked select
-        MVT MaskVT = MVT::getVectorVT(MVT::i1, NumElts);
-        SDValue Mask = DAG.getSetCC(DL, MaskVT, Cond,
-                                    DAG.getConstant(0, DL, Cond.getValueType()),
-                                    ISD::SETNE);
-        return DAG.getSelect(DL, VT, Mask, Op1, Op2);
-      }
-
       // For vector floating point with AVX, use VBLENDV-style operations
       if (HasAVX && (VectorWidth == 256 || VectorWidth == 128)) {
         // Convert to bitwise operations using the condition
         MVT IntVT = VT.changeVectorElementTypeToInteger();
-        SDValue IntOp1 = DAG.getBitcast(IntVT, Op1);
-        SDValue IntOp2 = DAG.getBitcast(IntVT, Op2);
+        SDValue IntOp1 = DAG.getBitcast(IntVT, TrueOp);
+        SDValue IntOp2 = DAG.getBitcast(IntVT, FalseOp);
 
         // Create the CTSELECT node with integer types
         SDValue IntResult =
@@ -25008,131 +24998,8 @@ SDValue X86TargetLowering::LowerCTSELECT(SDValue Op, SelectionDAG &DAG) const {
     // use the generic X86 CTSELECT node which will be matched by the patterns
     SDValue CC = DAG.getTargetConstant(X86::COND_NE, DL, MVT::i8);
     SDValue EFLAGS = EmitTest(Cond, X86::COND_NE, DL, DAG, Subtarget);
-
-    // Create the X86 CTSELECT node - note operand order: false, true, cc, flags
-    return DAG.getNode(X86ISD::CTSELECT, DL, VT, Op2, Op1, CC, EFLAGS);
-  }
-
-  // Lower FP selects into a CMP/AND/ANDN/OR sequence when the necessary SSE ops
-  // are available, Otherwise FP cmovs get lowered into a less efficient branch
-  // sequence later.
-  if (Cond.getOpcode() == ISD::SETCC && isScalarFPTypeInSSEReg(VT) &&
-      VT == Cond.getOperand(0).getSimpleValueType() && Cond->hasOneUse()) {
-    SDValue CondOp0 = Cond.getOperand(0), CondOp1 = Cond.getOperand(1);
-    bool IsAlwaysSignaling;
-    unsigned SSECC =
-        translateX86FSETCC(cast<CondCodeSDNode>(Cond.getOperand(2))->get(),
-                           CondOp0, CondOp1, IsAlwaysSignaling);
-
-    // TODO: CTSELECT does not look for AVX support and optimize it using vector
-    // select
-    if (SSECC < 8) {
-      SDValue Cmp = DAG.getNode(X86ISD::FSETCC, DL, VT, CondOp0, CondOp1,
-                                DAG.getTargetConstant(SSECC, DL, MVT::i8));
-      SDValue AndN = DAG.getNode(X86ISD::FANDN, DL, VT, Cmp, Op2);
-      SDValue And = DAG.getNode(X86ISD::FAND, DL, VT, Cmp, Op1);
-      return DAG.getNode(X86ISD::FOR, DL, VT, AndN, And);
-    }
-  }
-
-  // Try to optimize special patterns when comparing with zero
-  if (Cond.getOpcode() == X86ISD::SETCC &&
-      Cond.getOperand(1).getOpcode() == X86ISD::CMP &&
-      isNullConstant(Cond.getOperand(1).getOperand(1))) {
-
-    SDValue CmpOp0 = Cond.getOperand(1).getOperand(0);
-    unsigned CondCode = Cond.getConstantOperandVal(0);
-
-    // Special handling for __builtin_ffs(X) - 1 pattern
-    auto MatchFFSMinus1 = [&](SDValue Op1, SDValue Op2) {
-      return (Op1.getOpcode() == ISD::CTTZ_ZERO_UNDEF && Op1.hasOneUse() &&
-              Op1.getOperand(0) == CmpOp0 && isAllOnesConstant(Op2));
-    };
-
-    if ((VT == MVT::i32 || VT == MVT::i64) &&
-        ((CondCode == X86::COND_NE && MatchFFSMinus1(Op1, Op2)) ||
-         (CondCode == X86::COND_E && MatchFFSMinus1(Op2, Op1)))) {
-      // Keep original comparison for FFS pattern
-    } else {
-
-      auto TryOptimizeAndOneSelect =
-          [&](SDValue CmpOp0, SDValue Op1, SDValue Op2, unsigned CondCode,
-              SDLoc DL, SelectionDAG &DAG,
-              const X86Subtarget &Subtarget) -> SDValue {
-        if (CondCode != X86::COND_E || CmpOp0.getOpcode() != ISD::AND ||
-            !isOneConstant(CmpOp0.getOperand(1)))
-          return SDValue();
-
-        EVT CmpVT = CmpOp0.getValueType();
-        EVT SelectVT = Op1.getValueType();
-
-        /// function to create a mask for LSB operations
-        auto SplatLSB = [&](EVT SplatVT) {
-          SDValue AdjustedValue;
-
-          if (CmpVT.bitsGT(SplatVT)) {
-            AdjustedValue = DAG.getNode(ISD::TRUNCATE, DL, SplatVT, CmpOp0);
-          } else if (CmpVT.bitsLT(SplatVT)) {
-            SDValue Extended =
-                DAG.getNode(ISD::ANY_EXTEND, DL, SplatVT, CmpOp0.getOperand(0));
-            AdjustedValue = DAG.getNode(ISD::AND, DL, SplatVT, Extended,
-                                        DAG.getConstant(1, DL, SplatVT));
-          } else {
-            AdjustedValue = CmpOp0;
-          }
-
-          return DAG.getNegative(AdjustedValue, DL, SplatVT);
-        };
-
-        // CTSELECT (AND(X,1) == 0), 0, -1 -> NEG(AND(X,1))
-        if (isNullConstant(Op1) && isAllOnesConstant(Op2))
-          return SplatLSB(SelectVT);
-
-        // CTSELECT (AND(X,1) == 0), C1, C2 ->
-        // XOR(C1,AND(NEG(AND(X,1)),XOR(C1,C2))
-        if (!Subtarget.canUseCMOV() && isa<ConstantSDNode>(Op1) &&
-            isa<ConstantSDNode>(Op2)) {
-          SDValue Mask = SplatLSB(SelectVT);
-          SDValue Diff = DAG.getNode(ISD::XOR, DL, SelectVT, Op1, Op2);
-          SDValue Flip = DAG.getNode(ISD::AND, DL, SelectVT, Mask, Diff);
-          return DAG.getNode(ISD::XOR, DL, SelectVT, Op1, Flip);
-        }
-
-        return SDValue();
-      };
-
-      /// Try to optimize min/max patterns with sign bit operations
-      auto TryOptimizeMinMaxPattern =
-          [&](SDValue CmpOp0, SDValue Op1, SDValue Op2, unsigned CondCode,
-              MVT VT, SDLoc DL, SelectionDAG &DAG,
-              const X86Subtarget &Subtarget) -> SDValue {
-        if ((VT != MVT::i32 && VT != MVT::i64) || !isNullConstant(Op2) ||
-            CmpOp0 != Op1)
-          return SDValue();
-
-        if (CondCode == X86::COND_S ||                     // smin(x, 0)
-            (CondCode == X86::COND_G && hasAndNot(Op1))) { // smax(x, 0)
-          // (ctselect (x < 0), x, 0) -> ((x >> (size_in_bits(x)-1))) & x
-          // (ctselect (x > 0), x, 0) -> (~(x >> (size_in_bits(x)-1))) & x
-          unsigned ShCt = VT.getSizeInBits() - 1;
-          SDValue ShiftAmt = DAG.getConstant(ShCt, DL, VT);
-          SDValue Shift = DAG.getNode(ISD::SRA, DL, VT, Op1, ShiftAmt);
-          if (CondCode == X86::COND_G)
-            Shift = DAG.getNOT(DL, Shift, VT);
-          return DAG.getNode(ISD::AND, DL, VT, Shift, Op1);
-        }
-        return SDValue();
-      };
-      // Try AND(X,1) optimizations
-      if (SDValue OptResult = TryOptimizeAndOneSelect(
-              CmpOp0, Op1, Op2, CondCode, DL, DAG, Subtarget))
-        return OptResult;
-
-      // Try min/max pattern optimizations
-      if (SDValue OptResult = TryOptimizeMinMaxPattern(
-              CmpOp0, Op1, Op2, CondCode, VT, DL, DAG, Subtarget))
-        return OptResult;
-    }
+    // Create the X86 CTSELECT node - note operand order: true, false, cc, flags
+    return DAG.getNode(X86ISD::CTSELECT, DL, VT, FalseOp, TrueOp, CC, EFLAGS);
   }
 
   // Look past (and (setcc_carry (cmp ...)), 1)
@@ -25202,9 +25069,9 @@ SDValue X86TargetLowering::LowerCTSELECT(SDValue Op, SelectionDAG &DAG) const {
       ProcessConditionFlags(Cond, VT, DL, DAG, Subtarget);
 
   // Handle i8 CTSELECT with truncate optimization
-  if (Op.getValueType() == MVT::i8 &&
-      Op1.getOpcode() == ISD::TRUNCATE && Op2.getOpcode() == ISD::TRUNCATE) {
-    SDValue T1 = Op1.getOperand(0), T2 = Op2.getOperand(0);
+  if (Op.getValueType() == MVT::i8 && TrueOp.getOpcode() == ISD::TRUNCATE &&
+      FalseOp.getOpcode() == ISD::TRUNCATE) {
+    SDValue T1 = TrueOp.getOperand(0), T2 = FalseOp.getOperand(0);
     if (T1.getValueType() == T2.getValueType() &&
         T1.getOpcode() != ISD::CopyFromReg &&
         T2.getOpcode() != ISD::CopyFromReg) {
@@ -25216,26 +25083,26 @@ SDValue X86TargetLowering::LowerCTSELECT(SDValue Op, SelectionDAG &DAG) const {
 
   // Promote small integer types to avoid partial register stalls
   if ((Op.getValueType() == MVT::i8) ||
-      (Op.getValueType() == MVT::i16 && !X86::mayFoldLoad(Op1, Subtarget) &&
-       !X86::mayFoldLoad(Op2, Subtarget))) {
-    Op1 = DAG.getNode(ISD::ANY_EXTEND, DL, MVT::i32, Op1);
-    Op2 = DAG.getNode(ISD::ANY_EXTEND, DL, MVT::i32, Op2);
-    SDValue Ops[] = {Op2, Op1, CC, ProcessedCond};
+      (Op.getValueType() == MVT::i16 && !X86::mayFoldLoad(TrueOp, Subtarget) &&
+       !X86::mayFoldLoad(FalseOp, Subtarget))) {
+    TrueOp = DAG.getNode(ISD::ANY_EXTEND, DL, MVT::i32, TrueOp);
+    FalseOp = DAG.getNode(ISD::ANY_EXTEND, DL, MVT::i32, FalseOp);
+    SDValue Ops[] = {FalseOp, TrueOp, CC, ProcessedCond};
     SDValue Cmov = DAG.getNode(X86ISD::CTSELECT, DL, MVT::i32, Ops);
     return DAG.getNode(ISD::TRUNCATE, DL, Op.getValueType(), Cmov);
   }
 
   if (isScalarFPTypeInSSEReg(VT)) {
     MVT IntVT = (VT == MVT::f32) ? MVT::i32 : MVT::i64;
-    Op1 = DAG.getBitcast(IntVT, Op1);
-    Op2 = DAG.getBitcast(IntVT, Op2);
-    SDValue Ops[] = {Op2, Op1, CC, ProcessedCond};
+    TrueOp = DAG.getBitcast(IntVT, TrueOp);
+    FalseOp = DAG.getBitcast(IntVT, FalseOp);
+    SDValue Ops[] = {FalseOp, TrueOp, CC, ProcessedCond};
     SDValue CtSelect = DAG.getNode(X86ISD::CTSELECT, DL, IntVT, Ops);
     return DAG.getBitcast(VT, CtSelect);
   }
 
   // Create final CTSELECT node
-  SDValue Ops[] = {Op2, Op1, CC, ProcessedCond};
+  SDValue Ops[] = {FalseOp, TrueOp, CC, ProcessedCond};
   return DAG.getNode(X86ISD::CTSELECT, DL, Op.getValueType(), Ops,
                      Op->getFlags());
 }
@@ -36293,456 +36160,6 @@ X86TargetLowering::EmitLoweredCascadedSelect(MachineInstr &FirstCMOV,
   return SinkMBB;
 }
 
-struct CtSelectInstructions {
-  unsigned PAndOpc;
-  unsigned PAndnOpc;
-  unsigned POrOpc;
-  unsigned BroadcastOpc;
-  unsigned IntMoveOpc;
-  unsigned MoveOpc;
-  bool Use256;
-  bool UseVEX;
-  bool UseBlendInstr;
-};
-
-static CtSelectInstructions
-getCtSelectInstructions(unsigned Opcode, const X86Subtarget &Subtarget) {
-  CtSelectInstructions Instructions = {};
-
-  switch (Opcode) {
-  case X86::CTSELECT_V2F64:
-    if (Subtarget.hasSSE2()) {
-      Instructions.PAndOpc = X86::PANDrr;
-      Instructions.PAndnOpc = X86::PANDNrr;
-      Instructions.POrOpc = X86::PORrr;
-      Instructions.BroadcastOpc = X86::PSHUFDri;
-      Instructions.IntMoveOpc = X86::MOVDI2PDIrr;
-      Instructions.MoveOpc = X86::MOVAPDrr;
-    } else {
-      llvm_unreachable("Double precision vectors require SSE2");
-    }
-    break;
-  case X86::CTSELECT_V4F32:
-    if (Subtarget.hasSSE41()) {
-      Instructions.PAndOpc = X86::PANDrr;
-      Instructions.PAndnOpc = X86::PANDNrr;
-      Instructions.POrOpc = X86::PORrr;
-      Instructions.BroadcastOpc = X86::PSHUFDri;
-      Instructions.IntMoveOpc = X86::MOVDI2PDIrr;
-      Instructions.MoveOpc = X86::MOVAPSrr;
-      Instructions.UseBlendInstr = true;
-    } else if (Subtarget.hasSSE2()) {
-      Instructions.PAndOpc = X86::PANDrr;
-      Instructions.PAndnOpc = X86::PANDNrr;
-      Instructions.POrOpc = X86::PORrr;
-      Instructions.BroadcastOpc = X86::PSHUFDri;
-      Instructions.IntMoveOpc = X86::MOVDI2PDIrr;
-      Instructions.MoveOpc = X86::MOVAPSrr;
-    } else {
-      Instructions.PAndOpc = X86::ANDPSrr;
-      Instructions.PAndnOpc = X86::ANDNPSrr;
-      Instructions.POrOpc = X86::ORPSrr;
-      Instructions.BroadcastOpc = X86::SHUFPSrri;
-      Instructions.IntMoveOpc = X86::MOVSS2DIrr;
-      Instructions.MoveOpc = X86::MOVAPSrr;
-    }
-    break;
-  case X86::CTSELECT_V4I32:
-  case X86::CTSELECT_V2I64:
-  case X86::CTSELECT_V8I16:
-  case X86::CTSELECT_V16I8:
-    if (Subtarget.hasSSE2()) {
-      Instructions.PAndOpc = X86::PANDrr;
-      Instructions.PAndnOpc = X86::PANDNrr;
-      Instructions.POrOpc = X86::PORrr;
-      Instructions.BroadcastOpc = X86::PSHUFDri;
-      Instructions.IntMoveOpc = X86::MOVDI2PDIrr;
-      Instructions.MoveOpc = X86::MOVDQArr;
-    } else {
-      llvm_unreachable("Integer vector operations require SSE2");
-    }
-    break;
-  case X86::CTSELECT_V8F16:
-    if (Subtarget.hasSSE2()) {
-      Instructions.PAndOpc = X86::PANDrr;
-      Instructions.PAndnOpc = X86::PANDNrr;
-      Instructions.POrOpc = X86::PORrr;
-      Instructions.BroadcastOpc = X86::PSHUFDri;
-      Instructions.IntMoveOpc = X86::MOVDI2PDIrr;
-      Instructions.MoveOpc = X86::MOVDQArr;
-    } else {
-      llvm_unreachable("FP16 vector operations require SSE2");
-    }
-    break;
-  case X86::CTSELECT_V4F32X:
-  case X86::CTSELECT_V4I32X:
-  case X86::CTSELECT_V2F64X:
-  case X86::CTSELECT_V2I64X:
-  case X86::CTSELECT_V8I16X:
-  case X86::CTSELECT_V16I8X:
-  case X86::CTSELECT_V8F16X:
-    if (Subtarget.hasAVX()) {
-      Instructions.PAndOpc = X86::VPANDrr;
-      Instructions.PAndnOpc = X86::VPANDNrr;
-      Instructions.POrOpc = X86::VPORrr;
-      Instructions.BroadcastOpc = X86::VPSHUFDri;
-      Instructions.IntMoveOpc = X86::VMOVDI2PDIrr;
-      Instructions.MoveOpc = (Opcode == X86::CTSELECT_V4F32X) ? X86::VMOVAPSrr
-                             : (Opcode == X86::CTSELECT_V2F64X)
-                                 ? X86::VMOVAPDrr
-                                 : X86::VMOVDQArr;
-      Instructions.UseVEX = true;
-    } else {
-      llvm_unreachable("AVX variants require AVX support");
-    }
-    break;
-  case X86::CTSELECT_V8F32:
-  case X86::CTSELECT_V8I32:
-    if (Subtarget.hasAVX()) {
-      Instructions.PAndOpc = X86::VPANDYrr;
-      Instructions.PAndnOpc = X86::VPANDNYrr;
-      Instructions.POrOpc = X86::VPORYrr;
-      Instructions.BroadcastOpc = X86::VPERMILPSYri;
-      Instructions.IntMoveOpc = X86::VMOVDI2PDIrr;
-      Instructions.MoveOpc =
-          (Opcode == X86::CTSELECT_V8F32) ? X86::VMOVAPSYrr : X86::VMOVDQAYrr;
-      Instructions.Use256 = true;
-      Instructions.UseVEX = true;
-    } else {
-      llvm_unreachable("256-bit vectors require AVX");
-    }
-    break;
-  case X86::CTSELECT_V4F64:
-  case X86::CTSELECT_V4I64:
-    if (Subtarget.hasAVX()) {
-      Instructions.PAndOpc = X86::VPANDYrr;
-      Instructions.PAndnOpc = X86::VPANDNYrr;
-      Instructions.POrOpc = X86::VPORYrr;
-      Instructions.BroadcastOpc = X86::VPERMILPDYri;
-      Instructions.IntMoveOpc = X86::VMOVDI2PDIrr;
-      Instructions.MoveOpc =
-          (Opcode == X86::CTSELECT_V4F64) ? X86::VMOVAPDYrr : X86::VMOVDQAYrr;
-      Instructions.Use256 = true;
-      Instructions.UseVEX = true;
-    } else {
-      llvm_unreachable("256-bit vectors require AVX");
-    }
-    break;
-  case X86::CTSELECT_V16I16:
-  case X86::CTSELECT_V32I8:
-  case X86::CTSELECT_V16F16:
-    if (Subtarget.hasAVX2()) {
-      Instructions.PAndOpc = X86::VPANDYrr;
-      Instructions.PAndnOpc = X86::VPANDNYrr;
-      Instructions.POrOpc = X86::VPORYrr;
-      Instructions.BroadcastOpc = X86::VPERMILPSYri;
-      Instructions.IntMoveOpc = X86::VMOVDI2PDIrr;
-      Instructions.MoveOpc = X86::VMOVDQAYrr;
-      Instructions.Use256 = true;
-      Instructions.UseVEX = true;
-    } else if (Subtarget.hasAVX()) {
-      Instructions.PAndOpc = X86::VPANDYrr;
-      Instructions.PAndnOpc = X86::VPANDNYrr;
-      Instructions.POrOpc = X86::VPORYrr;
-      Instructions.BroadcastOpc = X86::VPERMILPSYri;
-      Instructions.IntMoveOpc = X86::VMOVDI2PDIrr;
-      Instructions.MoveOpc = X86::VMOVDQAYrr;
-      Instructions.Use256 = true;
-      Instructions.UseVEX = true;
-    } else {
-      llvm_unreachable("256-bit integer vectors require AVX");
-    }
-    break;
-  default:
-    llvm_unreachable("Unexpected CTSELECT opcode");
-  }
-
-  return Instructions;
-}
-
-static Register createScalarMask(MachineBasicBlock *MBB, MachineInstr &MI,
-                                 const MIMetadata &MIMD,
-                                 const TargetInstrInfo *TII,
-                                 MachineRegisterInfo &MRI) {
-  const TargetRegisterClass *GR8Class = &X86::GR8RegClass;
-  const TargetRegisterClass *GR32Class = &X86::GR32RegClass;
-
-  Register CondByteReg = MRI.createVirtualRegister(GR8Class);
-  Register CondReg = MRI.createVirtualRegister(GR32Class);
-  Register ScalarMaskReg = MRI.createVirtualRegister(GR32Class);
-
-  // Create a condition value using appropriate SETCC instruction
-  BuildMI(*MBB, MI, MIMD, TII->get(X86::SETCCr), CondByteReg)
-      .addImm(X86::COND_E)
-      .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-  // Zero-extend byte to 32-bit register (movzbl %al, %eax)
-  BuildMI(*MBB, MI, MIMD, TII->get(X86::MOVZX32rr8), CondReg)
-      .addReg(CondByteReg)
-      .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-  // Negate to convert 1 -> 0xFFFFFFFF, 0 -> 0x00000000 (negl %eax)
-  BuildMI(*MBB, MI, MIMD, TII->get(X86::NEG32r), ScalarMaskReg)
-      .addReg(CondReg)
-      .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-  return ScalarMaskReg;
-}
-
-static Register broadcastScalarMask(
-    MachineBasicBlock *MBB, MachineInstr &MI, const MIMetadata &MIMD,
-    const TargetInstrInfo *TII, MachineRegisterInfo &MRI,
-    Register ScalarMaskReg, const TargetRegisterClass *RC,
-    const CtSelectInstructions &Instructions, const X86Subtarget &Subtarget) {
-  // Step 1: Move scalar mask to vector register
-  Register VecFromScalarReg = MRI.createVirtualRegister(RC);
-  BuildMI(*MBB, MI, MIMD, TII->get(Instructions.IntMoveOpc), VecFromScalarReg)
-      .addReg(ScalarMaskReg)
-      .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-  // Step 2: Broadcast mask across all elements
-  Register MaskReg = MRI.createVirtualRegister(RC);
-  if (Instructions.Use256) {
-    // For 256-bit vectors, broadcast across all elements
-    BuildMI(*MBB, MI, MIMD, TII->get(Instructions.BroadcastOpc), MaskReg)
-        .addReg(VecFromScalarReg)
-        .addImm(0)
-        .setMIFlag(MachineInstr::MIFlag::NoMerge); // Broadcast element 0 to all
-                                                   // positions
-  } else {
-    // For 128-bit vectors
-    if (Subtarget.hasSSE2() || Instructions.UseVEX) {
-      // Use PSHUFD for efficient broadcasting
-      BuildMI(*MBB, MI, MIMD, TII->get(Instructions.BroadcastOpc), MaskReg)
-          .addReg(VecFromScalarReg)
-          .addImm(0x00)
-          .setMIFlag(MachineInstr::MIFlag::NoMerge); // Broadcast element 0 to
-                                                     // all positions
-    } else {
-      // SSE1 fallback using SHUFPS
-      BuildMI(*MBB, MI, MIMD, TII->get(Instructions.BroadcastOpc), MaskReg)
-          .addReg(VecFromScalarReg)
-          .addReg(VecFromScalarReg)
-          .addImm(0x00)
-          .setMIFlag(MachineInstr::MIFlag::NoMerge); // Broadcast element 0 to
-                                                     // all positions
-    }
-  }
-
-  return MaskReg;
-}
-
-MachineBasicBlock *
-X86TargetLowering::EmitLoweredCtSelect(MachineInstr &MI,
-                                       MachineBasicBlock *ThisMBB) const {
-  const TargetInstrInfo *TII = Subtarget.getInstrInfo();
-  const MIMetadata MIMD(MI);
-
-  MachineRegisterInfo &MRI = ThisMBB->getParent()->getRegInfo();
-  DebugLoc DL = MI.getDebugLoc();
-
-  // Extract operands: dst = ctselect src1, src2, cond
-  Register DstReg = MI.getOperand(0).getReg();
-  Register TrueReg = MI.getOperand(1).getReg();
-  Register FalseReg = MI.getOperand(2).getReg();
-  // Note: CondCode from MI.getOperand(3).getImm() is not used - we hardcode
-  // COND_E for sete
-
-  // Get the vector type to determine the appropriate instructions
-  const TargetRegisterClass *RC = MRI.getRegClass(DstReg);
-  unsigned Opcode = MI.getOpcode();
-
-  // Get instruction opcodes for this operation
-  CtSelectInstructions Instructions =
-      getCtSelectInstructions(Opcode, Subtarget);
-
-  // Step 1: Create scalar mask using SETCC + NEG
-  Register ScalarMaskReg = createScalarMask(ThisMBB, MI, MIMD, TII, MRI);
-
-  // Step 2: Move scalar mask to vector register and broadcast
-  Register MaskReg = broadcastScalarMask(
-      ThisMBB, MI, MIMD, TII, MRI, ScalarMaskReg, RC, Instructions, Subtarget);
-
-  // Step 3: Implement blend operation
-  if (Instructions.UseBlendInstr && Subtarget.hasSSE41() &&
-      !Instructions.Use256) {
-    // Use dedicated blend instructions for SSE4.1+
-    unsigned BlendOpc;
-    switch (Opcode) {
-    case X86::CTSELECT_V4F32:
-      BlendOpc = X86::BLENDVPSrr0;
-      break;
-    case X86::CTSELECT_V2F64:
-      BlendOpc = X86::BLENDVPDrr0;
-      break;
-    default:
-      BlendOpc = X86::PBLENDVBrr0;
-      break;
-    }
-
-    // BLENDV uses XMM0 as implicit mask register
-    BuildMI(*ThisMBB, MI, MIMD, TII->get(X86::MOVAPSrr), X86::XMM0)
-        .addReg(MaskReg)
-        .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-    BuildMI(*ThisMBB, MI, MIMD, TII->get(BlendOpc), DstReg)
-        .addReg(FalseReg)
-        .addReg(TrueReg)
-        .setMIFlag(MachineInstr::MIFlag::NoMerge);
-  } else {
-    // Use traditional AND/ANDN/OR approach
-    Register TempReg = MRI.createVirtualRegister(RC);
-    Register MaskCopyReg = MRI.createVirtualRegister(RC);
-    Register VecAndReg = MRI.createVirtualRegister(RC);
-    Register VecAndnReg = MRI.createVirtualRegister(RC);
-    Register FinalResultReg = MRI.createVirtualRegister(RC);
-
-    // Copy mask for first operation
-    BuildMI(*ThisMBB, MI, MIMD, TII->get(Instructions.MoveOpc), TempReg)
-        .addReg(MaskReg)
-        .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-    // mask & true_val
-    BuildMI(*ThisMBB, MI, MIMD, TII->get(Instructions.PAndOpc), VecAndReg)
-        .addReg(TempReg)
-        .addReg(TrueReg)
-        .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-    // Copy mask for second operation
-    BuildMI(*ThisMBB, MI, MIMD, TII->get(Instructions.MoveOpc), MaskCopyReg)
-        .addReg(MaskReg)
-        .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-    // ~mask & false_val
-    BuildMI(*ThisMBB, MI, MIMD, TII->get(Instructions.PAndnOpc), VecAndnReg)
-        .addReg(MaskCopyReg)
-        .addReg(FalseReg)
-        .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-    // Combine results
-    BuildMI(*ThisMBB, MI, MIMD, TII->get(Instructions.POrOpc), FinalResultReg)
-        .addReg(VecAndReg)
-        .addReg(VecAndnReg)
-        .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-    // Move final result to destination
-    BuildMI(*ThisMBB, MI, MIMD, TII->get(Instructions.MoveOpc), DstReg)
-        .addReg(FinalResultReg)
-        .setMIFlag(MachineInstr::MIFlag::NoMerge);
-  }
-  // Remove the original instruction
-  MI.eraseFromParent();
-  return ThisMBB;
-}
-
-MachineBasicBlock *
-X86TargetLowering::EmitLoweredCtSelectNoCMOV(MachineInstr &MI,
-                                             MachineBasicBlock *ThisMBB) const {
-  const TargetInstrInfo *TII = Subtarget.getInstrInfo();
-  const MIMetadata MIMD(MI);
-  MachineRegisterInfo &MRI = ThisMBB->getParent()->getRegInfo();
-  DebugLoc DL = MI.getDebugLoc();
-
-  // Get operands
-  Register DstReg = MI.getOperand(0).getReg();
-  Register TrueReg = MI.getOperand(1).getReg();
-  Register FalseReg = MI.getOperand(2).getReg();
-
-  X86::CondCode CC = X86::CondCode(MI.getOperand(3).getImm());
-  X86::CondCode OppCC = X86::GetOppositeBranchCondition(CC);
-
-  const TargetRegisterClass *RC = MRI.getRegClass(DstReg);
-  unsigned SETCCOp, MOVZXOp, NEGOp, ANDOp, XOROp, OROp;
-  const TargetRegisterClass *condRC;
-
-  if (RC == &X86::GR8RegClass) {
-    SETCCOp = X86::SETCCr;
-    MOVZXOp = 0; // No extension needed for 8-bit
-    NEGOp = X86::NEG8r;
-    ANDOp = X86::AND8rr;
-    XOROp = X86::XOR8ri;
-    OROp = X86::OR8rr;
-    condRC = &X86::GR8RegClass;
-  } else if (RC == &X86::GR16RegClass) {
-    SETCCOp = X86::SETCCr;
-    MOVZXOp = X86::MOVZX16rr8;
-    NEGOp = X86::NEG16r;
-    ANDOp = X86::AND16rr;
-    XOROp = X86::XOR16ri;
-    OROp = X86::OR16rr;
-    condRC = &X86::GR16RegClass;
-  } else if (RC == &X86::GR32RegClass) {
-    SETCCOp = X86::SETCCr;
-    MOVZXOp = X86::MOVZX32rr8;
-    NEGOp = X86::NEG32r;
-    ANDOp = X86::AND32rr;
-    XOROp = X86::XOR32ri;
-    OROp = X86::OR32rr;
-    condRC = &X86::GR32RegClass;
-  } else {
-    llvm_unreachable("Unsupported register class for conditional select");
-  }
-
-  // Step 1: Create condition value using SETCC instruction
-  Register CondByteReg = MRI.createVirtualRegister(&X86::GR8RegClass);
-  BuildMI(*ThisMBB, MI, MIMD, TII->get(SETCCOp), CondByteReg)
-      .addImm(OppCC)
-      .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-  Register CondReg;
-  if (RC == &X86::GR8RegClass) {
-    // For 8-bit, use the byte register directly
-    CondReg = CondByteReg;
-  } else {
-    // For 16/32-bit, zero-extend the byte to the target size
-    CondReg = MRI.createVirtualRegister(condRC);
-    BuildMI(*ThisMBB, MI, MIMD, TII->get(MOVZXOp), CondReg)
-        .addReg(CondByteReg)
-        .setMIFlag(MachineInstr::MIFlag::NoMerge);
-  }
-
-  // Step 2: Convert condition to mask (1 -> 0xFFFF..., 0 -> 0x0000...)
-  // Use NEG to create all-ones mask when condition is true
-  Register MaskReg = MRI.createVirtualRegister(condRC);
-  BuildMI(*ThisMBB, MI, MIMD, TII->get(NEGOp), MaskReg)
-      .addReg(CondReg)
-      .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-  // Step 3: Implement conditional select using bitwise operations
-  // Result = (TrueReg & Mask) | (FalseReg & ~Mask)
-
-  // Create inverted mask (~Mask)
-  Register InvMaskReg = MRI.createVirtualRegister(condRC);
-  BuildMI(*ThisMBB, MI, MIMD, TII->get(XOROp), InvMaskReg)
-      .addReg(MaskReg)
-      .addImm(-1)
-      .setMIFlag(MachineInstr::MIFlag::NoMerge); // XOR with all 1s to invert
-
-  // Compute TrueReg & Mask
-  Register TrueMaskedReg = MRI.createVirtualRegister(condRC);
-  BuildMI(*ThisMBB, MI, MIMD, TII->get(ANDOp), TrueMaskedReg)
-      .addReg(TrueReg)
-      .addReg(MaskReg)
-      .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-  // Compute FalseReg & ~Mask
-  Register FalseMaskedReg = MRI.createVirtualRegister(condRC);
-  BuildMI(*ThisMBB, MI, MIMD, TII->get(ANDOp), FalseMaskedReg)
-      .addReg(FalseReg)
-      .addReg(InvMaskReg)
-      .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-  // Final result: (TrueReg & Mask) | (FalseReg & ~Mask)
-  BuildMI(*ThisMBB, MI, MIMD, TII->get(OROp), DstReg)
-      .addReg(TrueMaskedReg)
-      .addReg(FalseMaskedReg)
-      .setMIFlag(MachineInstr::MIFlag::NoMerge);
-
-  // Remove the original instruction
-  MI.eraseFromParent();
-  return ThisMBB;
-}
-
 MachineBasicBlock *
 X86TargetLowering::EmitLoweredSelect(MachineInstr &MI,
                                      MachineBasicBlock *ThisMBB) const {
@@ -38143,6 +37560,124 @@ X86TargetLowering::emitPatchableEventCall(MachineInstr &MI,
 }
 
 MachineBasicBlock *
+X86TargetLowering::EmitLoweredCtSelect(MachineInstr &MI,
+                                       MachineBasicBlock *ThisMBB) const {
+  const TargetInstrInfo *TII = Subtarget.getInstrInfo();
+  const MIMetadata MIMD(MI);
+  MachineRegisterInfo &MRI = ThisMBB->getParent()->getRegInfo();
+  DebugLoc DL = MI.getDebugLoc();
+
+  // Get operands
+  Register DstReg = MI.getOperand(0).getReg();
+  Register TrueReg = MI.getOperand(1).getReg();
+  Register FalseReg = MI.getOperand(2).getReg();
+
+  X86::CondCode CC = X86::CondCode(MI.getOperand(3).getImm());
+  X86::CondCode OppCC = X86::GetOppositeBranchCondition(CC);
+
+  const TargetRegisterClass *RC = MRI.getRegClass(DstReg);
+  unsigned SETCCOp, MOVZXOp, NEGOp, ANDOp, XOROp, OROp;
+  const TargetRegisterClass *condRC;
+
+  if (RC == &X86::GR8RegClass) {
+    SETCCOp = X86::SETCCr;
+    MOVZXOp = 0; // No extension needed for 8-bit
+    NEGOp = X86::NEG8r;
+    ANDOp = X86::AND8rr;
+    XOROp = X86::XOR8ri;
+    OROp = X86::OR8rr;
+    condRC = &X86::GR8RegClass;
+  } else if (RC == &X86::GR16RegClass) {
+    SETCCOp = X86::SETCCr;
+    MOVZXOp = X86::MOVZX16rr8;
+    NEGOp = X86::NEG16r;
+    ANDOp = X86::AND16rr;
+    XOROp = X86::XOR16ri;
+    OROp = X86::OR16rr;
+    condRC = &X86::GR16RegClass;
+  } else if (RC == &X86::GR32RegClass) {
+    SETCCOp = X86::SETCCr;
+    MOVZXOp = X86::MOVZX32rr8;
+    NEGOp = X86::NEG32r;
+    ANDOp = X86::AND32rr;
+    XOROp = X86::XOR32ri;
+    OROp = X86::OR32rr;
+    condRC = &X86::GR32RegClass;
+  } else {
+    llvm_unreachable("Unsupported register class for conditional select");
+  }
+
+  auto BundleStart = MI.getIterator();
+
+  // Step 1: Create condition value using SETCC instruction
+  Register CondByteReg = MRI.createVirtualRegister(&X86::GR8RegClass);
+  BuildMI(*ThisMBB, MI, MIMD, TII->get(SETCCOp), CondByteReg)
+      .addImm(OppCC)
+      .setMIFlag(MachineInstr::MIFlag::NoMerge);
+
+  Register CondReg;
+  if (RC == &X86::GR8RegClass) {
+    // For 8-bit, use the byte register directly
+    CondReg = CondByteReg;
+  } else {
+    // For 16/32-bit, zero-extend the byte to the target size
+    CondReg = MRI.createVirtualRegister(condRC);
+    BuildMI(*ThisMBB, MI, MIMD, TII->get(MOVZXOp), CondReg)
+        .addReg(CondByteReg)
+        .setMIFlag(MachineInstr::MIFlag::NoMerge);
+  }
+
+  // Step 2: Convert condition to mask (1 -> 0xFFFF..., 0 -> 0x0000...)
+  // Use NEG to create all-ones mask when condition is true
+  Register MaskReg = MRI.createVirtualRegister(condRC);
+  BuildMI(*ThisMBB, MI, MIMD, TII->get(NEGOp), MaskReg)
+      .addReg(CondReg)
+      .setMIFlag(MachineInstr::MIFlag::NoMerge);
+
+  // Step 3: Implement conditional select using bitwise operations
+  // Result = (TrueReg & Mask) | (FalseReg & ~Mask)
+
+  // Create inverted mask (~Mask)
+  Register InvMaskReg = MRI.createVirtualRegister(condRC);
+  BuildMI(*ThisMBB, MI, MIMD, TII->get(XOROp), InvMaskReg)
+      .addReg(MaskReg)
+      .addImm(-1)
+      .setMIFlag(MachineInstr::MIFlag::NoMerge); // XOR with all 1s to invert
+
+  // Compute TrueReg & Mask
+  Register TrueMaskedReg = MRI.createVirtualRegister(condRC);
+  BuildMI(*ThisMBB, MI, MIMD, TII->get(ANDOp), TrueMaskedReg)
+      .addReg(TrueReg)
+      .addReg(MaskReg)
+      .setMIFlag(MachineInstr::MIFlag::NoMerge);
+
+  // Compute FalseReg & ~Mask
+  Register FalseMaskedReg = MRI.createVirtualRegister(condRC);
+  BuildMI(*ThisMBB, MI, MIMD, TII->get(ANDOp), FalseMaskedReg)
+      .addReg(FalseReg)
+      .addReg(InvMaskReg)
+      .setMIFlag(MachineInstr::MIFlag::NoMerge);
+
+  // Final result: (TrueReg & Mask) | (FalseReg & ~Mask)
+  BuildMI(*ThisMBB, MI, MIMD, TII->get(OROp), DstReg)
+      .addReg(TrueMaskedReg)
+      .addReg(FalseMaskedReg)
+      .setMIFlag(MachineInstr::MIFlag::NoMerge);
+
+  // Remove the original instruction
+  MI.eraseFromParent();
+
+  auto BundleEnd = MI.getIterator();
+  if (BundleStart != BundleEnd) {
+    // Only bundle if we have multiple instructions
+    MachineInstr *BundleHeader =
+        BuildMI(*ThisMBB, BundleStart, DL, TII->get(TargetOpcode::BUNDLE));
+    finalizeBundle(*ThisMBB, BundleHeader->getIterator(), std::next(BundleEnd));
+  }
+  return ThisMBB;
+}
+
+MachineBasicBlock *
 X86TargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
                                                MachineBasicBlock *BB) const {
   MachineFunction *MF = BB->getParent();
@@ -38203,39 +37738,9 @@ X86TargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
   case X86::CMOV_VK64:
     return EmitLoweredSelect(MI, BB);
 
-  case X86::CTSELECT_V2F64:
-  case X86::CTSELECT_V4F32:
-  case X86::CTSELECT_V8F16:
-  case X86::CTSELECT_V2I64:
-  case X86::CTSELECT_V4I32:
-  case X86::CTSELECT_V8I16:
-  case X86::CTSELECT_V16I8:
-  case X86::CTSELECT_V2F64X:
-  case X86::CTSELECT_V4F32X:
-  case X86::CTSELECT_V8F16X:
-  case X86::CTSELECT_V2I64X:
-  case X86::CTSELECT_V4I32X:
-  case X86::CTSELECT_V8I16X:
-  case X86::CTSELECT_V16I8X:
-  case X86::CTSELECT_V4I64:
-  case X86::CTSELECT_V8I32:
-  case X86::CTSELECT_V16I16:
-  case X86::CTSELECT_V32I8:
-  case X86::CTSELECT_V4F64:
-  case X86::CTSELECT_V8F32:
-  case X86::CTSELECT_V16F16:
-  case X86::CTSELECT_V8I64:
-  case X86::CTSELECT_V16I32:
-  case X86::CTSELECT_V32I16:
-  case X86::CTSELECT_V64I8:
-  case X86::CTSELECT_V8F64:
-  case X86::CTSELECT_V16F32:
-  case X86::CTSELECT_V32F16:
-    return EmitLoweredCtSelect(MI, BB);
-
   case X86::CTSELECT_GR16rr:
   case X86::CTSELECT_GR32rr:
-    return EmitLoweredCtSelectNoCMOV(MI, BB);
+    return EmitLoweredCtSelect(MI, BB);
 
   case X86::CTSELECT_FP32rr:
   case X86::CTSELECT_FP64rr:

--- a/llvm/lib/Target/X86/X86ISelLowering.h
+++ b/llvm/lib/Target/X86/X86ISelLowering.h
@@ -1851,9 +1851,6 @@ namespace llvm {
     MachineBasicBlock *EmitLoweredSelect(MachineInstr &I,
                                          MachineBasicBlock *BB) const;
 
-    MachineBasicBlock *EmitLoweredCtSelectNoCMOV(MachineInstr &MI,
-                                                 MachineBasicBlock *BB) const;
-
     MachineBasicBlock *EmitLoweredCtSelect(MachineInstr &MI,
                                            MachineBasicBlock *BB) const;
 

--- a/llvm/lib/Target/X86/X86InstrCMovSetCC.td
+++ b/llvm/lib/Target/X86/X86InstrCMovSetCC.td
@@ -114,14 +114,16 @@ let Uses = [EFLAGS], isNotDuplicable = 1, isPseudo = 1 in {
 
   multiclass CTSELECT<X86TypeInfo t> {
     // register-only
-    let isCommutable = 0, SchedRW = [WriteCMOV] in {
+    let isCommutable = 0, SchedRW = [WriteCMOV],
+        AsmString = "ctselect\\t$dst, $src1, $src2, $cond" in {
       def rr : PseudoI<(outs t.RegClass:$dst),
                        (ins t.RegClass:$src1, t.RegClass:$src2, i8imm:$cond),
                        [(set t.RegClass:$dst, (X86ctselect t.RegClass:$src1, t.RegClass:$src2, timm:$cond, EFLAGS))]>;
     }
 
     // register-memory
-    let SchedRW = [WriteCMOV.Folded, WriteCMOV.ReadAfterFold] in {
+    let SchedRW = [WriteCMOV.Folded, WriteCMOV.ReadAfterFold],
+        AsmString = "ctselect\\t$dst, $src1, $src2, $cond" in {
       def rm : PseudoI<(outs t.RegClass:$dst),
                        (ins t.RegClass:$src1, t.MemOperand:$src2, i8imm:$cond),
                        [(set t.RegClass:$dst, (X86ctselect t.RegClass:$src1, (t.LoadNode addr:$src2), timm:$cond, EFLAGS))]>;
@@ -137,106 +139,203 @@ let isCodeGenOnly = 1, hasSideEffects = 1, ForceDisassemble = 1 in {
   }
 }
 
-let Uses = [EFLAGS], usesCustomInserter = 1, isNotDuplicable = 1, isPseudo = 1, hasSideEffects = 1 in {
-  // 128-bit vector types
-  let Predicates = [HasSSE1] in {
-    def CTSELECT_V4F32  : PseudoI<(outs VR128:$dst), (ins VR128:$t, VR128:$f, i8imm:$cond),
-                                  [(set VR128:$dst, (v4f32 (X86ctselect VR128:$t, VR128:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V2F64  : PseudoI<(outs VR128:$dst), (ins VR128:$t, VR128:$f, i8imm:$cond),
-                                  [(set VR128:$dst, (v2f64 (X86ctselect VR128:$t, VR128:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V4I32  : PseudoI<(outs VR128:$dst), (ins VR128:$t, VR128:$f, i8imm:$cond),
-                                  [(set VR128:$dst, (v4i32 (X86ctselect VR128:$t, VR128:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V2I64  : PseudoI<(outs VR128:$dst), (ins VR128:$t, VR128:$f, i8imm:$cond),
-                                  [(set VR128:$dst, (v2i64 (X86ctselect VR128:$t, VR128:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V8I16  : PseudoI<(outs VR128:$dst), (ins VR128:$t, VR128:$f, i8imm:$cond),
-                                  [(set VR128:$dst, (v8i16 (X86ctselect VR128:$t, VR128:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V16I8  : PseudoI<(outs VR128:$dst), (ins VR128:$t, VR128:$f, i8imm:$cond),
-                                  [(set VR128:$dst, (v16i8 (X86ctselect VR128:$t, VR128:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V8F16  : PseudoI<(outs VR128:$dst), (ins VR128:$t, VR128:$f, i8imm:$cond),
-                                  [(set VR128:$dst, (v8f16 (X86ctselect VR128:$t, VR128:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-  }
+// CTSELECT_VEC base class
+class CTSELECT_VEC<RegisterClass VRc, RegisterClass GRc>
+    : PseudoI<
+        (outs VRc:$dst, VRc:$tmpx, GRc:$tmpg),
+        (ins  VRc:$t,   VRc:$f,   i8imm:$cond),
+        []
+      > {
+  let Uses            = [EFLAGS];
+  let isPseudo        = 1;
+  let isNotDuplicable = 1;
+  let hasSideEffects  = 1;
+  let AsmString       = "ctselect\t$dst, $f, $t, $cond";
+  let SchedRW         = [];
+}
 
-  // 128-bit vector types (AVX versions)
-  let Predicates = [HasAVX] in {
-    def CTSELECT_V4F32X : PseudoI<(outs VR128X:$dst), (ins VR128X:$t, VR128X:$f, i8imm:$cond),
-                                  [(set VR128X:$dst, (v4f32 (X86ctselect VR128X:$t, VR128X:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V2F64X : PseudoI<(outs VR128X:$dst), (ins VR128X:$t, VR128X:$f, i8imm:$cond),
-                                  [(set VR128X:$dst, (v2f64 (X86ctselect VR128X:$t, VR128X:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V4I32X : PseudoI<(outs VR128X:$dst), (ins VR128X:$t, VR128X:$f, i8imm:$cond),
-                                  [(set VR128X:$dst, (v4i32 (X86ctselect VR128X:$t, VR128X:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V2I64X : PseudoI<(outs VR128X:$dst), (ins VR128X:$t, VR128X:$f, i8imm:$cond),
-                                  [(set VR128X:$dst, (v2i64 (X86ctselect VR128X:$t, VR128X:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V8I16X : PseudoI<(outs VR128X:$dst), (ins VR128X:$t, VR128X:$f, i8imm:$cond),
-                                  [(set VR128X:$dst, (v8i16 (X86ctselect VR128X:$t, VR128X:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V16I8X : PseudoI<(outs VR128X:$dst), (ins VR128X:$t, VR128X:$f, i8imm:$cond),
-                                  [(set VR128X:$dst, (v16i8 (X86ctselect VR128X:$t, VR128X:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V8F16X : PseudoI<(outs VR128X:$dst), (ins VR128X:$t, VR128X:$f, i8imm:$cond),
-                                  [(set VR128X:$dst, (v8f16 (X86ctselect VR128X:$t, VR128X:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-  }
+// Width-specific class aliases
+class CTSELECT_VEC128  : CTSELECT_VEC<VR128,  GR32>;
+class CTSELECT_VEC128X : CTSELECT_VEC<VR128X, GR32>;
+class CTSELECT_VEC256  : CTSELECT_VEC<VR256,  GR32>;
+class CTSELECT_VEC512  : CTSELECT_VEC<VR512,  GR32>;
 
-  // 256-bit vector types
-  let Predicates = [HasAVX] in {
-    def CTSELECT_V8F32  : PseudoI<(outs VR256:$dst), (ins VR256:$t, VR256:$f, i8imm:$cond),
-                                  [(set VR256:$dst, (v8f32 (X86ctselect VR256:$t, VR256:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V4F64  : PseudoI<(outs VR256:$dst), (ins VR256:$t, VR256:$f, i8imm:$cond),
-                                  [(set VR256:$dst, (v4f64 (X86ctselect VR256:$t, VR256:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V8I32  : PseudoI<(outs VR256:$dst), (ins VR256:$t, VR256:$f, i8imm:$cond),
-                                  [(set VR256:$dst, (v8i32 (X86ctselect VR256:$t, VR256:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V4I64  : PseudoI<(outs VR256:$dst), (ins VR256:$t, VR256:$f, i8imm:$cond),
-                                  [(set VR256:$dst, (v4i64 (X86ctselect VR256:$t, VR256:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V16I16 : PseudoI<(outs VR256:$dst), (ins VR256:$t, VR256:$f, i8imm:$cond),
-                                  [(set VR256:$dst, (v16i16 (X86ctselect VR256:$t, VR256:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V32I8  : PseudoI<(outs VR256:$dst), (ins VR256:$t, VR256:$f, i8imm:$cond),
-                                  [(set VR256:$dst, (v32i8 (X86ctselect VR256:$t, VR256:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-    def CTSELECT_V16F16 : PseudoI<(outs VR256:$dst), (ins VR256:$t, VR256:$f, i8imm:$cond),
-                                  [(set VR256:$dst, (v16f16 (X86ctselect VR256:$t, VR256:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[]>;
-  }
 
-  // 512-bit vector types
-  let Predicates = [HasAVX512] in {
-    def CTSELECT_V16F32 : PseudoI<(outs VR512:$dst), (ins VR512:$t, VR512:$f, i8imm:$cond),
-                                  [(set VR512:$dst, (v16f32 (X86ctselect VR512:$t, VR512:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[WriteCMOV]>;
-    def CTSELECT_V8F64  : PseudoI<(outs VR512:$dst), (ins VR512:$t, VR512:$f, i8imm:$cond),
-                                  [(set VR512:$dst, (v8f64 (X86ctselect VR512:$t, VR512:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[WriteCMOV]>;
-    def CTSELECT_V16I32 : PseudoI<(outs VR512:$dst), (ins VR512:$t, VR512:$f, i8imm:$cond),
-                                  [(set VR512:$dst, (v16i32 (X86ctselect VR512:$t, VR512:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[WriteCMOV]>;
-    def CTSELECT_V8I64  : PseudoI<(outs VR512:$dst), (ins VR512:$t, VR512:$f, i8imm:$cond),
-                                  [(set VR512:$dst, (v8i64 (X86ctselect VR512:$t, VR512:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[WriteCMOV]>;
-    def CTSELECT_V32I16 : PseudoI<(outs VR512:$dst), (ins VR512:$t, VR512:$f, i8imm:$cond),
-                                  [(set VR512:$dst, (v32i16 (X86ctselect VR512:$t, VR512:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[WriteCMOV]>;
-    def CTSELECT_V64I8  : PseudoI<(outs VR512:$dst), (ins VR512:$t, VR512:$f, i8imm:$cond),
-                                  [(set VR512:$dst, (v64i8 (X86ctselect VR512:$t, VR512:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[WriteCMOV]>;
-    def CTSELECT_V32F16 : PseudoI<(outs VR512:$dst), (ins VR512:$t, VR512:$f, i8imm:$cond),
-                                  [(set VR512:$dst, (v32f16 (X86ctselect VR512:$t, VR512:$f, timm:$cond, EFLAGS)))]>,
-                                  Sched<[WriteCMOV]>;
+//===----------------------------------------------------------------------===//
+// 128-bit pseudos (SSE2 baseline; we use PXOR/PAND/MOVD/PSHUFD in the expander)
+//===----------------------------------------------------------------------===//
+let Predicates = [HasSSE2] in {
+
+  def CTSELECT_V4F32 : CTSELECT_VEC128 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
   }
+  def CTSELECT_V2F64 : CTSELECT_VEC128 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V4I32 : CTSELECT_VEC128 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V2I64 : CTSELECT_VEC128 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V8I16 : CTSELECT_VEC128 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V16I8 : CTSELECT_VEC128 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  // If your build has v8f16, keep this; otherwise comment it out.
+  def CTSELECT_V8F16 : CTSELECT_VEC128 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+}
+
+let Predicates = [HasAVX] in {
+
+  def CTSELECT_V4F32X : CTSELECT_VEC128X {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V2F64X : CTSELECT_VEC128X {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V4I32X : CTSELECT_VEC128X {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V2I64X : CTSELECT_VEC128X {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V8I16X : CTSELECT_VEC128X {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V16I8X : CTSELECT_VEC128X {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  // If your build has v8f16, keep this; otherwise comment it out.
+  def CTSELECT_V8F16X : CTSELECT_VEC128X {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// 256-bit pseudos
+//===----------------------------------------------------------------------===//
+let Predicates = [HasAVX] in {
+
+  def CTSELECT_V8F32  : CTSELECT_VEC256 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V4F64  : CTSELECT_VEC256 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V8I32  : CTSELECT_VEC256 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V4I64  : CTSELECT_VEC256 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V16I16 : CTSELECT_VEC256 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V32I8  : CTSELECT_VEC256 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  // If your build has v16f16, keep this; otherwise comment it out.
+  def CTSELECT_V16F16 : CTSELECT_VEC256 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// 512-bit pseudos
+//===----------------------------------------------------------------------===//
+
+// Core AVX-512F types
+let Predicates = [HasAVX512] in {
+  def CTSELECT_V16F32 : CTSELECT_VEC512 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V8F64  : CTSELECT_VEC512 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V16I32 : CTSELECT_VEC512 {
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+  def CTSELECT_V8I64  : CTSELECT_VEC512{
+    let Constraints = "@earlyclobber $dst,@earlyclobber $tmpx,@earlyclobber $tmpg";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Selection patterns: X86ctselect(...), EFLAGS -> CTSELECT_V*
+//
+// NOTE:
+//  * The SDNode carries Glue from CMP/TEST (due to SDNPInGlue).
+//  * We list EFLAGS explicitly in the pattern (X86 style) to model the arch read.
+//  * Temps (tmpx/tmpy,tmpg) are not in the pattern; they’re outs allocated by RA.
+//===----------------------------------------------------------------------===//
+
+let Predicates = [HasSSE2] in {
+
+  // 128-bit integer
+  def : Pat<(v4i32 (X86ctselect VR128:$t, VR128:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V4I32 VR128:$t, VR128:$f, timm:$cc)>;
+  def : Pat<(v2i64 (X86ctselect VR128:$t, VR128:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V2I64 VR128:$t, VR128:$f, timm:$cc)>;
+  def : Pat<(v8i16 (X86ctselect VR128:$t, VR128:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V8I16 VR128:$t, VR128:$f, timm:$cc)>;
+  def : Pat<(v16i8 (X86ctselect VR128:$t, VR128:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V16I8 VR128:$t, VR128:$f, timm:$cc)>;
+
+  // 128-bit float (bitwise-equivalent ops in expander)
+  def : Pat<(v4f32 (X86ctselect VR128:$t, VR128:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V4F32 VR128:$t, VR128:$f, timm:$cc)>;
+  def : Pat<(v2f64 (X86ctselect VR128:$t, VR128:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V2F64 VR128:$t, VR128:$f, timm:$cc)>;
+
+  // 128-bit f16 (optional)
+  def : Pat<(v8f16 (X86ctselect VR128:$t, VR128:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V8F16 VR128:$t, VR128:$f, timm:$cc)>;
+}
+
+let Predicates = [HasAVX] in {
+
+  // 256-bit integer
+  def : Pat<(v8i32  (X86ctselect VR256:$t, VR256:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V8I32  VR256:$t, VR256:$f, timm:$cc)>;
+  def : Pat<(v4i64  (X86ctselect VR256:$t, VR256:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V4I64  VR256:$t, VR256:$f, timm:$cc)>;
+  def : Pat<(v16i16 (X86ctselect VR256:$t, VR256:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V16I16 VR256:$t, VR256:$f, timm:$cc)>;
+  def : Pat<(v32i8  (X86ctselect VR256:$t, VR256:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V32I8  VR256:$t, VR256:$f, timm:$cc)>;
+
+  // 256-bit float (bitwise-equivalent ops in expander)
+  def : Pat<(v8f32 (X86ctselect VR256:$t, VR256:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V8F32 VR256:$t, VR256:$f, timm:$cc)>;
+  def : Pat<(v4f64 (X86ctselect VR256:$t, VR256:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V4F64 VR256:$t, VR256:$f, timm:$cc)>;
+
+  // 256-bit f16 (optional)
+  def : Pat<(v16f16 (X86ctselect VR256:$t, VR256:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V16F16 VR256:$t, VR256:$f, timm:$cc)>;
+}
+
+//===----------------------------------------------------------------------===//
+// 512-bit selection patterns
+//  Note: SDNode is X86ctselect with SDNPInGlue; pattern names EFLAGS explicitly.
+//  Temps ($tmpx,$tmpg) are outs allocated by RA; not mentioned in patterns.
+//===----------------------------------------------------------------------===//
+
+let Predicates = [HasAVX512] in {
+  def : Pat<(v16f32 (X86ctselect VR512:$t, VR512:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V16F32 VR512:$t, VR512:$f, timm:$cc)>;
+  def : Pat<(v8f64 (X86ctselect VR512:$t, VR512:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V8F64  VR512:$t, VR512:$f, timm:$cc)>;
+
+  def : Pat<(v16i32 (X86ctselect VR512:$t, VR512:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V16I32 VR512:$t, VR512:$f, timm:$cc)>;
+  def : Pat<(v8i64 (X86ctselect VR512:$t, VR512:$f, (i8 timm:$cc), EFLAGS)),
+            (CTSELECT_V8I64  VR512:$t, VR512:$f, timm:$cc)>;
 }
 
 let Predicates = [HasCMOV, HasCF] in {

--- a/llvm/lib/Target/X86/X86InstrFragments.td
+++ b/llvm/lib/Target/X86/X86InstrFragments.td
@@ -155,7 +155,7 @@ def X86ctest   : SDNode<"X86ISD::CTEST",    SDTX86Ccmp>;
 def X86cload    : SDNode<"X86ISD::CLOAD",   SDTX86Cload, [SDNPHasChain, SDNPMayLoad, SDNPMemOperand]>;
 def X86cstore   : SDNode<"X86ISD::CSTORE",  SDTX86Cstore, [SDNPHasChain, SDNPMayStore, SDNPMemOperand]>;
 
-def X86ctselect: SDNode<"X86ISD::CTSELECT", SDTX86CtSelect>;
+def X86ctselect: SDNode<"X86ISD::CTSELECT", SDTX86CtSelect, [SDNPInGlue]>;
 def X86cmov    : SDNode<"X86ISD::CMOV",     SDTX86Cmov>;
 def X86brcond  : SDNode<"X86ISD::BRCOND",   SDTX86BrCond,
                         [SDNPHasChain]>;

--- a/llvm/lib/Target/X86/X86InstrInfo.h
+++ b/llvm/lib/Target/X86/X86InstrInfo.h
@@ -683,7 +683,9 @@ private:
                       int &FrameIndex) const;
 
   /// Expand the CTSELECT pseudo-instructions.
-  bool expandCtSelect(unsigned Opcode, MachineInstrBuilder &MIB) const;
+  bool expandCtSelectWithCMOV(MachineInstr &MI) const;
+
+  bool expandCtSelectVector(MachineInstr &MI) const;
 
   /// Returns true iff the routine could find two commutable operands in the
   /// given machine instruction with 3 vector inputs.

--- a/llvm/test/CodeGen/X86/ctselect-optimization.ll
+++ b/llvm/test/CodeGen/X86/ctselect-optimization.ll
@@ -248,9 +248,14 @@ define i64 @test_ctselect_i64_smin_zero(i64 %x) {
 define float @test_ctselect_f32_zero_positive(float %x) {
 ; CHECK-LABEL: test_ctselect_f32_zero_positive:
 ; CHECK:       # %bb.0:
+; CHECK-NEXT:    movd %xmm0, %eax
 ; CHECK-NEXT:    xorps %xmm1, %xmm1
-; CHECK-NEXT:    cmpltss %xmm0, %xmm1
-; CHECK-NEXT:    andps %xmm1, %xmm0
+; CHECK-NEXT:    ucomiss %xmm1, %xmm0
+; CHECK-NEXT:    seta %cl
+; CHECK-NEXT:    xorl %edx, %edx
+; CHECK-NEXT:    testb %cl, %cl
+; CHECK-NEXT:    cmovnel %eax, %edx
+; CHECK-NEXT:    movd %edx, %xmm0
 ; CHECK-NEXT:    retq
   %cmp = fcmp ogt float %x, 0.0
   %result = call float @llvm.ct.select.f32(i1 %cmp, float %x, float 0.0)
@@ -260,9 +265,14 @@ define float @test_ctselect_f32_zero_positive(float %x) {
 define double @test_ctselect_f64_zero_positive(double %x) {
 ; CHECK-LABEL: test_ctselect_f64_zero_positive:
 ; CHECK:       # %bb.0:
+; CHECK-NEXT:    movq %xmm0, %rax
 ; CHECK-NEXT:    xorpd %xmm1, %xmm1
-; CHECK-NEXT:    cmpltsd %xmm0, %xmm1
-; CHECK-NEXT:    andpd %xmm1, %xmm0
+; CHECK-NEXT:    ucomisd %xmm1, %xmm0
+; CHECK-NEXT:    seta %cl
+; CHECK-NEXT:    xorl %edx, %edx
+; CHECK-NEXT:    testb %cl, %cl
+; CHECK-NEXT:    cmovneq %rax, %rdx
+; CHECK-NEXT:    movq %rdx, %xmm0
 ; CHECK-NEXT:    retq
   %cmp = fcmp ogt double %x, 0.0
   %result = call double @llvm.ct.select.f64(i1 %cmp, double %x, double 0.0)

--- a/llvm/test/CodeGen/X86/ctselect-vector.ll
+++ b/llvm/test/CodeGen/X86/ctselect-vector.ll
@@ -9,47 +9,53 @@
 define <4 x i32> @test_ctselect_v4i32(i1 %cond, <4 x i32> %a, <4 x i32> %b) {
 ; SSE2-LABEL: test_ctselect_v4i32:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb $1, %dil
-; SSE2-NEXT:    sete %al
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
 ; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm2
-; SSE2-NEXT:    pshufd $0, %xmm2, %xmm2
-; SSE2-NEXT:    movdqa %xmm2, %xmm2
-; SSE2-NEXT:    pand %xmm2, %xmm1
-; SSE2-NEXT:    pandn %xmm0, %xmm2
-; SSE2-NEXT:    por %xmm1, %xmm2
+; SSE2-NEXT:    xorps %xmm3, %xmm3
+; SSE2-NEXT:    movd %eax, %xmm3
+; SSE2-NEXT:    pshufd $0, %xmm3, %xmm3
+; SSE2-NEXT:    movdqa %xmm3, %xmm2
+; SSE2-NEXT:    pand %xmm0, %xmm3
+; SSE2-NEXT:    pandn %xmm1, %xmm2
+; SSE2-NEXT:    por %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm0
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v4i32:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    xorl %eax, %eax
 ; AVX-NEXT:    testb $1, %dil
-; AVX-NEXT:    sete %al
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
 ; AVX-NEXT:    negl %eax
-; AVX-NEXT:    movd %eax, %xmm2
-; AVX-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm2
-; AVX-NEXT:    pand %xmm2, %xmm1
-; AVX-NEXT:    pandn %xmm0, %xmm2
-; AVX-NEXT:    por %xmm1, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm0
+; AVX-NEXT:    xorps %xmm3, %xmm3
+; AVX-NEXT:    movd %eax, %xmm3
+; AVX-NEXT:    pshufd $0, %xmm3, %xmm3
+; AVX-NEXT:    movdqa %xmm3, %xmm2
+; AVX-NEXT:    pand %xmm0, %xmm3
+; AVX-NEXT:    pandn %xmm1, %xmm2
+; AVX-NEXT:    por %xmm3, %xmm2
+; AVX-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v4i32:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb $1, %dil
-; AVX2-NEXT:    sete %al
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
 ; AVX2-NEXT:    negl %eax
-; AVX2-NEXT:    movd %eax, %xmm2
-; AVX2-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm2
-; AVX2-NEXT:    pand %xmm2, %xmm1
-; AVX2-NEXT:    pandn %xmm0, %xmm2
-; AVX2-NEXT:    por %xmm1, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm0
+; AVX2-NEXT:    xorps %xmm3, %xmm3
+; AVX2-NEXT:    movd %eax, %xmm3
+; AVX2-NEXT:    pshufd $0, %xmm3, %xmm3
+; AVX2-NEXT:    movdqa %xmm3, %xmm2
+; AVX2-NEXT:    pand %xmm0, %xmm3
+; AVX2-NEXT:    pandn %xmm1, %xmm2
+; AVX2-NEXT:    por %xmm3, %xmm2
+; AVX2-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v4i32:
@@ -68,47 +74,53 @@ define <4 x i32> @test_ctselect_v4i32(i1 %cond, <4 x i32> %a, <4 x i32> %b) {
 define <4 x float> @test_ctselect_v4f32(i1 %cond, <4 x float> %a, <4 x float> %b) {
 ; SSE2-LABEL: test_ctselect_v4f32:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb $1, %dil
-; SSE2-NEXT:    sete %al
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
 ; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm2
-; SSE2-NEXT:    pshufd $0, %xmm2, %xmm2
-; SSE2-NEXT:    movdqa %xmm2, %xmm2
-; SSE2-NEXT:    pand %xmm2, %xmm1
-; SSE2-NEXT:    pandn %xmm0, %xmm2
-; SSE2-NEXT:    por %xmm1, %xmm2
+; SSE2-NEXT:    xorps %xmm3, %xmm3
+; SSE2-NEXT:    movd %eax, %xmm3
+; SSE2-NEXT:    pshufd $0, %xmm3, %xmm3
+; SSE2-NEXT:    movdqa %xmm3, %xmm2
+; SSE2-NEXT:    pand %xmm0, %xmm3
+; SSE2-NEXT:    pandn %xmm1, %xmm2
+; SSE2-NEXT:    por %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm0
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v4f32:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    xorl %eax, %eax
 ; AVX-NEXT:    testb $1, %dil
-; AVX-NEXT:    sete %al
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
 ; AVX-NEXT:    negl %eax
-; AVX-NEXT:    movd %eax, %xmm2
-; AVX-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm2
-; AVX-NEXT:    pand %xmm2, %xmm1
-; AVX-NEXT:    pandn %xmm0, %xmm2
-; AVX-NEXT:    por %xmm1, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm0
+; AVX-NEXT:    xorps %xmm3, %xmm3
+; AVX-NEXT:    movd %eax, %xmm3
+; AVX-NEXT:    pshufd $0, %xmm3, %xmm3
+; AVX-NEXT:    movdqa %xmm3, %xmm2
+; AVX-NEXT:    pand %xmm0, %xmm3
+; AVX-NEXT:    pandn %xmm1, %xmm2
+; AVX-NEXT:    por %xmm3, %xmm2
+; AVX-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v4f32:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb $1, %dil
-; AVX2-NEXT:    sete %al
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
 ; AVX2-NEXT:    negl %eax
-; AVX2-NEXT:    movd %eax, %xmm2
-; AVX2-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm2
-; AVX2-NEXT:    pand %xmm2, %xmm1
-; AVX2-NEXT:    pandn %xmm0, %xmm2
-; AVX2-NEXT:    por %xmm1, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm0
+; AVX2-NEXT:    xorps %xmm3, %xmm3
+; AVX2-NEXT:    movd %eax, %xmm3
+; AVX2-NEXT:    pshufd $0, %xmm3, %xmm3
+; AVX2-NEXT:    movdqa %xmm3, %xmm2
+; AVX2-NEXT:    pand %xmm0, %xmm3
+; AVX2-NEXT:    pandn %xmm1, %xmm2
+; AVX2-NEXT:    por %xmm3, %xmm2
+; AVX2-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v4f32:
@@ -127,47 +139,53 @@ define <4 x float> @test_ctselect_v4f32(i1 %cond, <4 x float> %a, <4 x float> %b
 define <2 x i64> @test_ctselect_v2i64(i1 %cond, <2 x i64> %a, <2 x i64> %b) {
 ; SSE2-LABEL: test_ctselect_v2i64:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb $1, %dil
-; SSE2-NEXT:    sete %al
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
 ; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm2
-; SSE2-NEXT:    pshufd $0, %xmm2, %xmm2
-; SSE2-NEXT:    movdqa %xmm2, %xmm2
-; SSE2-NEXT:    pand %xmm2, %xmm1
-; SSE2-NEXT:    pandn %xmm0, %xmm2
-; SSE2-NEXT:    por %xmm1, %xmm2
+; SSE2-NEXT:    xorps %xmm3, %xmm3
+; SSE2-NEXT:    movd %eax, %xmm3
+; SSE2-NEXT:    pshufd $0, %xmm3, %xmm3
+; SSE2-NEXT:    movdqa %xmm3, %xmm2
+; SSE2-NEXT:    pand %xmm0, %xmm3
+; SSE2-NEXT:    pandn %xmm1, %xmm2
+; SSE2-NEXT:    por %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm0
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v2i64:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    xorl %eax, %eax
 ; AVX-NEXT:    testb $1, %dil
-; AVX-NEXT:    sete %al
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
 ; AVX-NEXT:    negl %eax
-; AVX-NEXT:    movd %eax, %xmm2
-; AVX-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm2
-; AVX-NEXT:    pand %xmm2, %xmm1
-; AVX-NEXT:    pandn %xmm0, %xmm2
-; AVX-NEXT:    por %xmm1, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm0
+; AVX-NEXT:    xorps %xmm3, %xmm3
+; AVX-NEXT:    movd %eax, %xmm3
+; AVX-NEXT:    pshufd $0, %xmm3, %xmm3
+; AVX-NEXT:    movdqa %xmm3, %xmm2
+; AVX-NEXT:    pand %xmm0, %xmm3
+; AVX-NEXT:    pandn %xmm1, %xmm2
+; AVX-NEXT:    por %xmm3, %xmm2
+; AVX-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v2i64:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb $1, %dil
-; AVX2-NEXT:    sete %al
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
 ; AVX2-NEXT:    negl %eax
-; AVX2-NEXT:    movd %eax, %xmm2
-; AVX2-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm2
-; AVX2-NEXT:    pand %xmm2, %xmm1
-; AVX2-NEXT:    pandn %xmm0, %xmm2
-; AVX2-NEXT:    por %xmm1, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm0
+; AVX2-NEXT:    xorps %xmm3, %xmm3
+; AVX2-NEXT:    movd %eax, %xmm3
+; AVX2-NEXT:    pshufd $0, %xmm3, %xmm3
+; AVX2-NEXT:    movdqa %xmm3, %xmm2
+; AVX2-NEXT:    pand %xmm0, %xmm3
+; AVX2-NEXT:    pandn %xmm1, %xmm2
+; AVX2-NEXT:    por %xmm3, %xmm2
+; AVX2-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v2i64:
@@ -186,47 +204,53 @@ define <2 x i64> @test_ctselect_v2i64(i1 %cond, <2 x i64> %a, <2 x i64> %b) {
 define <2 x double> @test_ctselect_v2f64(i1 %cond, <2 x double> %a, <2 x double> %b) {
 ; SSE2-LABEL: test_ctselect_v2f64:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb $1, %dil
-; SSE2-NEXT:    sete %al
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
 ; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm2
-; SSE2-NEXT:    pshufd $0, %xmm2, %xmm2
-; SSE2-NEXT:    movdqa %xmm2, %xmm2
-; SSE2-NEXT:    pand %xmm2, %xmm1
-; SSE2-NEXT:    pandn %xmm0, %xmm2
-; SSE2-NEXT:    por %xmm1, %xmm2
+; SSE2-NEXT:    xorps %xmm3, %xmm3
+; SSE2-NEXT:    movd %eax, %xmm3
+; SSE2-NEXT:    pshufd $0, %xmm3, %xmm3
+; SSE2-NEXT:    movdqa %xmm3, %xmm2
+; SSE2-NEXT:    pand %xmm0, %xmm3
+; SSE2-NEXT:    pandn %xmm1, %xmm2
+; SSE2-NEXT:    por %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm0
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v2f64:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    xorl %eax, %eax
 ; AVX-NEXT:    testb $1, %dil
-; AVX-NEXT:    sete %al
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
 ; AVX-NEXT:    negl %eax
-; AVX-NEXT:    movd %eax, %xmm2
-; AVX-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm2
-; AVX-NEXT:    pand %xmm2, %xmm1
-; AVX-NEXT:    pandn %xmm0, %xmm2
-; AVX-NEXT:    por %xmm1, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm0
+; AVX-NEXT:    xorps %xmm3, %xmm3
+; AVX-NEXT:    movd %eax, %xmm3
+; AVX-NEXT:    pshufd $0, %xmm3, %xmm3
+; AVX-NEXT:    movdqa %xmm3, %xmm2
+; AVX-NEXT:    pand %xmm0, %xmm3
+; AVX-NEXT:    pandn %xmm1, %xmm2
+; AVX-NEXT:    por %xmm3, %xmm2
+; AVX-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v2f64:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb $1, %dil
-; AVX2-NEXT:    sete %al
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
 ; AVX2-NEXT:    negl %eax
-; AVX2-NEXT:    movd %eax, %xmm2
-; AVX2-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm2
-; AVX2-NEXT:    pand %xmm2, %xmm1
-; AVX2-NEXT:    pandn %xmm0, %xmm2
-; AVX2-NEXT:    por %xmm1, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm0
+; AVX2-NEXT:    xorps %xmm3, %xmm3
+; AVX2-NEXT:    movd %eax, %xmm3
+; AVX2-NEXT:    pshufd $0, %xmm3, %xmm3
+; AVX2-NEXT:    movdqa %xmm3, %xmm2
+; AVX2-NEXT:    pand %xmm0, %xmm3
+; AVX2-NEXT:    pandn %xmm1, %xmm2
+; AVX2-NEXT:    por %xmm3, %xmm2
+; AVX2-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v2f64:
@@ -246,57 +270,65 @@ define <2 x double> @test_ctselect_v2f64(i1 %cond, <2 x double> %a, <2 x double>
 define <8 x i32> @test_ctselect_v8i32(i1 %cond, <8 x i32> %a, <8 x i32> %b) {
 ; SSE2-LABEL: test_ctselect_v8i32:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb $1, %dil
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
 ; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm2
-; SSE2-NEXT:    pandn %xmm0, %xmm4
-; SSE2-NEXT:    por %xmm2, %xmm4
+; SSE2-NEXT:    xorps %xmm5, %xmm5
+; SSE2-NEXT:    movd %eax, %xmm5
+; SSE2-NEXT:    pshufd $0, %xmm5, %xmm5
+; SSE2-NEXT:    movdqa %xmm5, %xmm4
+; SSE2-NEXT:    pand %xmm0, %xmm5
+; SSE2-NEXT:    pandn %xmm2, %xmm4
+; SSE2-NEXT:    por %xmm5, %xmm4
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm2
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    pandn %xmm3, %xmm2
+; SSE2-NEXT:    por %xmm0, %xmm2
 ; SSE2-NEXT:    movdqa %xmm4, %xmm0
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm2
-; SSE2-NEXT:    pshufd $0, %xmm2, %xmm2
-; SSE2-NEXT:    movdqa %xmm2, %xmm2
-; SSE2-NEXT:    pand %xmm2, %xmm3
-; SSE2-NEXT:    pandn %xmm1, %xmm2
-; SSE2-NEXT:    por %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm1
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v8i32:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    xorl %eax, %eax
 ; AVX-NEXT:    testb $1, %dil
-; AVX-NEXT:    sete %al
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
 ; AVX-NEXT:    negl %eax
-; AVX-NEXT:    vmovd %eax, %ymm2
-; AVX-NEXT:    vshufps $0, %ymm2, %ymm2, %ymm2
-; AVX-NEXT:    vmovaps %ymm2, %ymm2
-; AVX-NEXT:    vandps %ymm1, %ymm2, %ymm1
-; AVX-NEXT:    vandnps %ymm0, %ymm2, %ymm0
-; AVX-NEXT:    vorps %ymm0, %ymm1, %ymm0
-; AVX-NEXT:    vmovaps %ymm0, %ymm0
+; AVX-NEXT:    xorps %ymm3, %ymm3
+; AVX-NEXT:    vmovd %eax, %ymm3
+; AVX-NEXT:    vshufps $0, %ymm3, %ymm3, %ymm3
+; AVX-NEXT:    vmovaps %ymm3, %ymm2
+; AVX-NEXT:    andps %ymm0, %ymm3
+; AVX-NEXT:    andnps %ymm1, %ymm2
+; AVX-NEXT:    orps %ymm3, %ymm2
+; AVX-NEXT:    vmovaps %ymm2, %ymm0
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v8i32:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb $1, %dil
-; AVX2-NEXT:    sete %al
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
 ; AVX2-NEXT:    negl %eax
-; AVX2-NEXT:    vmovd %eax, %ymm2
-; AVX2-NEXT:    vpshufd $0, %ymm2, %ymm2
-; AVX2-NEXT:    vmovdqa %ymm2, %ymm2
-; AVX2-NEXT:    vpand %ymm1, %ymm2, %ymm1
-; AVX2-NEXT:    vpandn %ymm0, %ymm2, %ymm0
-; AVX2-NEXT:    vpor %ymm0, %ymm1, %ymm0
-; AVX2-NEXT:    vmovdqa %ymm0, %ymm0
+; AVX2-NEXT:    xorps %ymm3, %ymm3
+; AVX2-NEXT:    vmovd %eax, %ymm3
+; AVX2-NEXT:    vpshufd $0, %ymm3, %ymm3
+; AVX2-NEXT:    vmovdqa %ymm3, %ymm2
+; AVX2-NEXT:    pand %ymm0, %ymm3
+; AVX2-NEXT:    pandn %ymm1, %ymm2
+; AVX2-NEXT:    por %ymm3, %ymm2
+; AVX2-NEXT:    vmovdqa %ymm2, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v8i32:
@@ -315,57 +347,65 @@ define <8 x i32> @test_ctselect_v8i32(i1 %cond, <8 x i32> %a, <8 x i32> %b) {
 define <8 x float> @test_ctselect_v8f32(i1 %cond, <8 x float> %a, <8 x float> %b) {
 ; SSE2-LABEL: test_ctselect_v8f32:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb $1, %dil
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
 ; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm2
-; SSE2-NEXT:    pandn %xmm0, %xmm4
-; SSE2-NEXT:    por %xmm2, %xmm4
+; SSE2-NEXT:    xorps %xmm5, %xmm5
+; SSE2-NEXT:    movd %eax, %xmm5
+; SSE2-NEXT:    pshufd $0, %xmm5, %xmm5
+; SSE2-NEXT:    movdqa %xmm5, %xmm4
+; SSE2-NEXT:    pand %xmm0, %xmm5
+; SSE2-NEXT:    pandn %xmm2, %xmm4
+; SSE2-NEXT:    por %xmm5, %xmm4
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm2
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    pandn %xmm3, %xmm2
+; SSE2-NEXT:    por %xmm0, %xmm2
 ; SSE2-NEXT:    movdqa %xmm4, %xmm0
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm2
-; SSE2-NEXT:    pshufd $0, %xmm2, %xmm2
-; SSE2-NEXT:    movdqa %xmm2, %xmm2
-; SSE2-NEXT:    pand %xmm2, %xmm3
-; SSE2-NEXT:    pandn %xmm1, %xmm2
-; SSE2-NEXT:    por %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm1
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v8f32:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    xorl %eax, %eax
 ; AVX-NEXT:    testb $1, %dil
-; AVX-NEXT:    sete %al
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
 ; AVX-NEXT:    negl %eax
-; AVX-NEXT:    vmovd %eax, %ymm2
-; AVX-NEXT:    vshufps $0, %ymm2, %ymm2, %ymm2
-; AVX-NEXT:    vmovaps %ymm2, %ymm2
-; AVX-NEXT:    vandps %ymm1, %ymm2, %ymm1
-; AVX-NEXT:    vandnps %ymm0, %ymm2, %ymm0
-; AVX-NEXT:    vorps %ymm0, %ymm1, %ymm0
-; AVX-NEXT:    vmovaps %ymm0, %ymm0
+; AVX-NEXT:    xorps %ymm3, %ymm3
+; AVX-NEXT:    vmovd %eax, %ymm3
+; AVX-NEXT:    vshufps $0, %ymm3, %ymm3, %ymm3
+; AVX-NEXT:    vmovaps %ymm3, %ymm2
+; AVX-NEXT:    andps %ymm0, %ymm3
+; AVX-NEXT:    andnps %ymm1, %ymm2
+; AVX-NEXT:    orps %ymm3, %ymm2
+; AVX-NEXT:    vmovaps %ymm2, %ymm0
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v8f32:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb $1, %dil
-; AVX2-NEXT:    sete %al
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
 ; AVX2-NEXT:    negl %eax
-; AVX2-NEXT:    vmovd %eax, %ymm2
-; AVX2-NEXT:    vpshufd $0, %ymm2, %ymm2
-; AVX2-NEXT:    vmovdqa %ymm2, %ymm2
-; AVX2-NEXT:    vpand %ymm1, %ymm2, %ymm1
-; AVX2-NEXT:    vpandn %ymm0, %ymm2, %ymm0
-; AVX2-NEXT:    vpor %ymm0, %ymm1, %ymm0
-; AVX2-NEXT:    vmovdqa %ymm0, %ymm0
+; AVX2-NEXT:    xorps %ymm3, %ymm3
+; AVX2-NEXT:    vmovd %eax, %ymm3
+; AVX2-NEXT:    vpshufd $0, %ymm3, %ymm3
+; AVX2-NEXT:    vmovdqa %ymm3, %ymm2
+; AVX2-NEXT:    pand %ymm0, %ymm3
+; AVX2-NEXT:    pandn %ymm1, %ymm2
+; AVX2-NEXT:    por %ymm3, %ymm2
+; AVX2-NEXT:    vmovdqa %ymm2, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v8f32:
@@ -384,57 +424,65 @@ define <8 x float> @test_ctselect_v8f32(i1 %cond, <8 x float> %a, <8 x float> %b
 define <4 x i64> @test_ctselect_v4i64(i1 %cond, <4 x i64> %a, <4 x i64> %b) {
 ; SSE2-LABEL: test_ctselect_v4i64:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb $1, %dil
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
 ; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm2
-; SSE2-NEXT:    pandn %xmm0, %xmm4
-; SSE2-NEXT:    por %xmm2, %xmm4
+; SSE2-NEXT:    xorps %xmm5, %xmm5
+; SSE2-NEXT:    movd %eax, %xmm5
+; SSE2-NEXT:    pshufd $0, %xmm5, %xmm5
+; SSE2-NEXT:    movdqa %xmm5, %xmm4
+; SSE2-NEXT:    pand %xmm0, %xmm5
+; SSE2-NEXT:    pandn %xmm2, %xmm4
+; SSE2-NEXT:    por %xmm5, %xmm4
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm2
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    pandn %xmm3, %xmm2
+; SSE2-NEXT:    por %xmm0, %xmm2
 ; SSE2-NEXT:    movdqa %xmm4, %xmm0
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm2
-; SSE2-NEXT:    pshufd $0, %xmm2, %xmm2
-; SSE2-NEXT:    movdqa %xmm2, %xmm2
-; SSE2-NEXT:    pand %xmm2, %xmm3
-; SSE2-NEXT:    pandn %xmm1, %xmm2
-; SSE2-NEXT:    por %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm1
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v4i64:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    xorl %eax, %eax
 ; AVX-NEXT:    testb $1, %dil
-; AVX-NEXT:    sete %al
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
 ; AVX-NEXT:    negl %eax
-; AVX-NEXT:    vmovd %eax, %ymm2
-; AVX-NEXT:    vshufpd $0, %ymm2, %ymm2, %ymm2
-; AVX-NEXT:    vmovapd %ymm2, %ymm2
-; AVX-NEXT:    vandpd %ymm1, %ymm2, %ymm1
-; AVX-NEXT:    vandnpd %ymm0, %ymm2, %ymm0
-; AVX-NEXT:    vorpd %ymm0, %ymm1, %ymm0
-; AVX-NEXT:    vmovapd %ymm0, %ymm0
+; AVX-NEXT:    xorps %ymm3, %ymm3
+; AVX-NEXT:    vmovd %eax, %ymm3
+; AVX-NEXT:    vshufpd $0, %ymm3, %ymm3, %ymm3
+; AVX-NEXT:    vmovapd %ymm3, %ymm2
+; AVX-NEXT:    andpd %ymm0, %ymm3
+; AVX-NEXT:    andnpd %ymm1, %ymm2
+; AVX-NEXT:    orpd %ymm3, %ymm2
+; AVX-NEXT:    vmovapd %ymm2, %ymm0
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v4i64:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb $1, %dil
-; AVX2-NEXT:    sete %al
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
 ; AVX2-NEXT:    negl %eax
-; AVX2-NEXT:    vmovd %eax, %ymm2
-; AVX2-NEXT:    vshufpd $0, %ymm2, %ymm2, %ymm2
-; AVX2-NEXT:    vmovapd %ymm2, %ymm2
-; AVX2-NEXT:    vandpd %ymm1, %ymm2, %ymm1
-; AVX2-NEXT:    vandnpd %ymm0, %ymm2, %ymm0
-; AVX2-NEXT:    vorpd %ymm0, %ymm1, %ymm0
-; AVX2-NEXT:    vmovapd %ymm0, %ymm0
+; AVX2-NEXT:    xorps %ymm3, %ymm3
+; AVX2-NEXT:    vmovd %eax, %ymm3
+; AVX2-NEXT:    vshufpd $0, %ymm3, %ymm3, %ymm3
+; AVX2-NEXT:    vmovapd %ymm3, %ymm2
+; AVX2-NEXT:    andpd %ymm0, %ymm3
+; AVX2-NEXT:    andnpd %ymm1, %ymm2
+; AVX2-NEXT:    orpd %ymm3, %ymm2
+; AVX2-NEXT:    vmovapd %ymm2, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v4i64:
@@ -453,57 +501,65 @@ define <4 x i64> @test_ctselect_v4i64(i1 %cond, <4 x i64> %a, <4 x i64> %b) {
 define <4 x double> @test_ctselect_v4f64(i1 %cond, <4 x double> %a, <4 x double> %b) {
 ; SSE2-LABEL: test_ctselect_v4f64:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb $1, %dil
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
 ; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm2
-; SSE2-NEXT:    pandn %xmm0, %xmm4
-; SSE2-NEXT:    por %xmm2, %xmm4
+; SSE2-NEXT:    xorps %xmm5, %xmm5
+; SSE2-NEXT:    movd %eax, %xmm5
+; SSE2-NEXT:    pshufd $0, %xmm5, %xmm5
+; SSE2-NEXT:    movdqa %xmm5, %xmm4
+; SSE2-NEXT:    pand %xmm0, %xmm5
+; SSE2-NEXT:    pandn %xmm2, %xmm4
+; SSE2-NEXT:    por %xmm5, %xmm4
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm2
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    pandn %xmm3, %xmm2
+; SSE2-NEXT:    por %xmm0, %xmm2
 ; SSE2-NEXT:    movdqa %xmm4, %xmm0
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm2
-; SSE2-NEXT:    pshufd $0, %xmm2, %xmm2
-; SSE2-NEXT:    movdqa %xmm2, %xmm2
-; SSE2-NEXT:    pand %xmm2, %xmm3
-; SSE2-NEXT:    pandn %xmm1, %xmm2
-; SSE2-NEXT:    por %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm1
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v4f64:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    xorl %eax, %eax
 ; AVX-NEXT:    testb $1, %dil
-; AVX-NEXT:    sete %al
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
 ; AVX-NEXT:    negl %eax
-; AVX-NEXT:    vmovd %eax, %ymm2
-; AVX-NEXT:    vshufpd $0, %ymm2, %ymm2, %ymm2
-; AVX-NEXT:    vmovapd %ymm2, %ymm2
-; AVX-NEXT:    vandpd %ymm1, %ymm2, %ymm1
-; AVX-NEXT:    vandnpd %ymm0, %ymm2, %ymm0
-; AVX-NEXT:    vorpd %ymm0, %ymm1, %ymm0
-; AVX-NEXT:    vmovapd %ymm0, %ymm0
+; AVX-NEXT:    xorps %ymm3, %ymm3
+; AVX-NEXT:    vmovd %eax, %ymm3
+; AVX-NEXT:    vshufpd $0, %ymm3, %ymm3, %ymm3
+; AVX-NEXT:    vmovapd %ymm3, %ymm2
+; AVX-NEXT:    andpd %ymm0, %ymm3
+; AVX-NEXT:    andnpd %ymm1, %ymm2
+; AVX-NEXT:    orpd %ymm3, %ymm2
+; AVX-NEXT:    vmovapd %ymm2, %ymm0
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v4f64:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb $1, %dil
-; AVX2-NEXT:    sete %al
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
 ; AVX2-NEXT:    negl %eax
-; AVX2-NEXT:    vmovd %eax, %ymm2
-; AVX2-NEXT:    vshufpd $0, %ymm2, %ymm2, %ymm2
-; AVX2-NEXT:    vmovapd %ymm2, %ymm2
-; AVX2-NEXT:    vandpd %ymm1, %ymm2, %ymm1
-; AVX2-NEXT:    vandnpd %ymm0, %ymm2, %ymm0
-; AVX2-NEXT:    vorpd %ymm0, %ymm1, %ymm0
-; AVX2-NEXT:    vmovapd %ymm0, %ymm0
+; AVX2-NEXT:    xorps %ymm3, %ymm3
+; AVX2-NEXT:    vmovd %eax, %ymm3
+; AVX2-NEXT:    vshufpd $0, %ymm3, %ymm3, %ymm3
+; AVX2-NEXT:    vmovapd %ymm3, %ymm2
+; AVX2-NEXT:    andpd %ymm0, %ymm3
+; AVX2-NEXT:    andnpd %ymm1, %ymm2
+; AVX2-NEXT:    orpd %ymm3, %ymm2
+; AVX2-NEXT:    vmovapd %ymm2, %ymm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v4f64:
@@ -523,97 +579,113 @@ define <4 x double> @test_ctselect_v4f64(i1 %cond, <4 x double> %a, <4 x double>
 define <16 x i32> @test_ctselect_v16i32(i1 %cond, <16 x i32> %a, <16 x i32> %b) {
 ; SSE2-LABEL: test_ctselect_v16i32:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb $1, %dil
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
 ; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm8
-; SSE2-NEXT:    pshufd $0, %xmm8, %xmm8
-; SSE2-NEXT:    movdqa %xmm8, %xmm8
-; SSE2-NEXT:    pand %xmm8, %xmm4
-; SSE2-NEXT:    pandn %xmm0, %xmm8
-; SSE2-NEXT:    por %xmm4, %xmm8
+; SSE2-NEXT:    xorps %xmm9, %xmm9
+; SSE2-NEXT:    movd %eax, %xmm9
+; SSE2-NEXT:    pshufd $0, %xmm9, %xmm9
+; SSE2-NEXT:    movdqa %xmm9, %xmm8
+; SSE2-NEXT:    pand %xmm0, %xmm9
+; SSE2-NEXT:    pandn %xmm4, %xmm8
+; SSE2-NEXT:    por %xmm9, %xmm8
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm4
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    pandn %xmm5, %xmm4
+; SSE2-NEXT:    por %xmm0, %xmm4
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm5
+; SSE2-NEXT:    pand %xmm2, %xmm0
+; SSE2-NEXT:    pandn %xmm6, %xmm5
+; SSE2-NEXT:    por %xmm0, %xmm5
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm6
+; SSE2-NEXT:    pand %xmm3, %xmm0
+; SSE2-NEXT:    pandn %xmm7, %xmm6
+; SSE2-NEXT:    por %xmm0, %xmm6
 ; SSE2-NEXT:    movdqa %xmm8, %xmm0
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    xorl %eax, %eax
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    pandn %xmm1, %xmm4
-; SSE2-NEXT:    por %xmm5, %xmm4
 ; SSE2-NEXT:    movdqa %xmm4, %xmm1
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
-; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm6
-; SSE2-NEXT:    pandn %xmm2, %xmm4
-; SSE2-NEXT:    por %xmm6, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm2
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm7
-; SSE2-NEXT:    pandn %xmm3, %xmm4
-; SSE2-NEXT:    por %xmm7, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm3
+; SSE2-NEXT:    movdqa %xmm5, %xmm2
+; SSE2-NEXT:    movdqa %xmm6, %xmm3
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v16i32:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    xorl %eax, %eax
 ; AVX-NEXT:    testb $1, %dil
-; AVX-NEXT:    sete %al
-; AVX-NEXT:    xorl %ecx, %ecx
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
 ; AVX-NEXT:    negl %eax
-; AVX-NEXT:    vmovd %eax, %ymm4
-; AVX-NEXT:    vshufps $0, %ymm4, %ymm4, %ymm4
-; AVX-NEXT:    vmovaps %ymm4, %ymm4
-; AVX-NEXT:    vandps %ymm2, %ymm4, %ymm2
-; AVX-NEXT:    vandnps %ymm0, %ymm4, %ymm0
-; AVX-NEXT:    vorps %ymm0, %ymm2, %ymm0
-; AVX-NEXT:    vmovaps %ymm0, %ymm0
-; AVX-NEXT:    sete %cl
-; AVX-NEXT:    negl %ecx
-; AVX-NEXT:    vmovd %ecx, %ymm2
-; AVX-NEXT:    vshufps $0, %ymm2, %ymm2, %ymm2
-; AVX-NEXT:    vmovaps %ymm2, %ymm2
-; AVX-NEXT:    vandps %ymm3, %ymm2, %ymm3
-; AVX-NEXT:    vandnps %ymm1, %ymm2, %ymm1
-; AVX-NEXT:    vorps %ymm1, %ymm3, %ymm1
-; AVX-NEXT:    vmovaps %ymm1, %ymm1
+; AVX-NEXT:    xorps %ymm5, %ymm5
+; AVX-NEXT:    vmovd %eax, %ymm5
+; AVX-NEXT:    vshufps $0, %ymm5, %ymm5, %ymm5
+; AVX-NEXT:    vmovaps %ymm5, %ymm4
+; AVX-NEXT:    andps %ymm0, %ymm5
+; AVX-NEXT:    andnps %ymm2, %ymm4
+; AVX-NEXT:    orps %ymm5, %ymm4
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
+; AVX-NEXT:    negl %eax
+; AVX-NEXT:    xorps %ymm0, %ymm0
+; AVX-NEXT:    vmovd %eax, %ymm0
+; AVX-NEXT:    vshufps $0, %ymm0, %ymm0, %ymm0
+; AVX-NEXT:    vmovaps %ymm0, %ymm2
+; AVX-NEXT:    andps %ymm1, %ymm0
+; AVX-NEXT:    andnps %ymm3, %ymm2
+; AVX-NEXT:    orps %ymm0, %ymm2
+; AVX-NEXT:    vmovaps %ymm4, %ymm0
+; AVX-NEXT:    vmovaps %ymm2, %ymm1
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v16i32:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb $1, %dil
-; AVX2-NEXT:    sete %al
-; AVX2-NEXT:    xorl %ecx, %ecx
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
 ; AVX2-NEXT:    negl %eax
-; AVX2-NEXT:    vmovd %eax, %ymm4
-; AVX2-NEXT:    vpshufd $0, %ymm4, %ymm4
-; AVX2-NEXT:    vmovdqa %ymm4, %ymm4
-; AVX2-NEXT:    vpand %ymm2, %ymm4, %ymm2
-; AVX2-NEXT:    vpandn %ymm0, %ymm4, %ymm0
-; AVX2-NEXT:    vpor %ymm0, %ymm2, %ymm0
-; AVX2-NEXT:    vmovdqa %ymm0, %ymm0
-; AVX2-NEXT:    sete %cl
-; AVX2-NEXT:    negl %ecx
-; AVX2-NEXT:    vmovd %ecx, %ymm2
-; AVX2-NEXT:    vpshufd $0, %ymm2, %ymm2
-; AVX2-NEXT:    vmovdqa %ymm2, %ymm2
-; AVX2-NEXT:    vpand %ymm3, %ymm2, %ymm3
-; AVX2-NEXT:    vpandn %ymm1, %ymm2, %ymm1
-; AVX2-NEXT:    vpor %ymm1, %ymm3, %ymm1
-; AVX2-NEXT:    vmovdqa %ymm1, %ymm1
+; AVX2-NEXT:    xorps %ymm5, %ymm5
+; AVX2-NEXT:    vmovd %eax, %ymm5
+; AVX2-NEXT:    vpshufd $0, %ymm5, %ymm5
+; AVX2-NEXT:    vmovdqa %ymm5, %ymm4
+; AVX2-NEXT:    pand %ymm0, %ymm5
+; AVX2-NEXT:    pandn %ymm2, %ymm4
+; AVX2-NEXT:    por %ymm5, %ymm4
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
+; AVX2-NEXT:    negl %eax
+; AVX2-NEXT:    pxor %ymm0, %ymm0
+; AVX2-NEXT:    vmovd %eax, %ymm0
+; AVX2-NEXT:    vpshufd $0, %ymm0, %ymm0
+; AVX2-NEXT:    vmovdqa %ymm0, %ymm2
+; AVX2-NEXT:    pand %ymm1, %ymm0
+; AVX2-NEXT:    pandn %ymm3, %ymm2
+; AVX2-NEXT:    por %ymm0, %ymm2
+; AVX2-NEXT:    vmovdqa %ymm4, %ymm0
+; AVX2-NEXT:    vmovdqa %ymm2, %ymm1
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v16i32:
@@ -632,97 +704,113 @@ define <16 x i32> @test_ctselect_v16i32(i1 %cond, <16 x i32> %a, <16 x i32> %b) 
 define <16 x float> @test_ctselect_v16f32(i1 %cond, <16 x float> %a, <16 x float> %b) {
 ; SSE2-LABEL: test_ctselect_v16f32:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb $1, %dil
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
 ; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm8
-; SSE2-NEXT:    pshufd $0, %xmm8, %xmm8
-; SSE2-NEXT:    movdqa %xmm8, %xmm8
-; SSE2-NEXT:    pand %xmm8, %xmm4
-; SSE2-NEXT:    pandn %xmm0, %xmm8
-; SSE2-NEXT:    por %xmm4, %xmm8
+; SSE2-NEXT:    xorps %xmm9, %xmm9
+; SSE2-NEXT:    movd %eax, %xmm9
+; SSE2-NEXT:    pshufd $0, %xmm9, %xmm9
+; SSE2-NEXT:    movdqa %xmm9, %xmm8
+; SSE2-NEXT:    pand %xmm0, %xmm9
+; SSE2-NEXT:    pandn %xmm4, %xmm8
+; SSE2-NEXT:    por %xmm9, %xmm8
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm4
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    pandn %xmm5, %xmm4
+; SSE2-NEXT:    por %xmm0, %xmm4
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm5
+; SSE2-NEXT:    pand %xmm2, %xmm0
+; SSE2-NEXT:    pandn %xmm6, %xmm5
+; SSE2-NEXT:    por %xmm0, %xmm5
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm6
+; SSE2-NEXT:    pand %xmm3, %xmm0
+; SSE2-NEXT:    pandn %xmm7, %xmm6
+; SSE2-NEXT:    por %xmm0, %xmm6
 ; SSE2-NEXT:    movdqa %xmm8, %xmm0
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    xorl %eax, %eax
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    pandn %xmm1, %xmm4
-; SSE2-NEXT:    por %xmm5, %xmm4
 ; SSE2-NEXT:    movdqa %xmm4, %xmm1
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
-; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm6
-; SSE2-NEXT:    pandn %xmm2, %xmm4
-; SSE2-NEXT:    por %xmm6, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm2
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm7
-; SSE2-NEXT:    pandn %xmm3, %xmm4
-; SSE2-NEXT:    por %xmm7, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm3
+; SSE2-NEXT:    movdqa %xmm5, %xmm2
+; SSE2-NEXT:    movdqa %xmm6, %xmm3
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v16f32:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    xorl %eax, %eax
 ; AVX-NEXT:    testb $1, %dil
-; AVX-NEXT:    sete %al
-; AVX-NEXT:    xorl %ecx, %ecx
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
 ; AVX-NEXT:    negl %eax
-; AVX-NEXT:    vmovd %eax, %ymm4
-; AVX-NEXT:    vshufps $0, %ymm4, %ymm4, %ymm4
-; AVX-NEXT:    vmovaps %ymm4, %ymm4
-; AVX-NEXT:    vandps %ymm2, %ymm4, %ymm2
-; AVX-NEXT:    vandnps %ymm0, %ymm4, %ymm0
-; AVX-NEXT:    vorps %ymm0, %ymm2, %ymm0
-; AVX-NEXT:    vmovaps %ymm0, %ymm0
-; AVX-NEXT:    sete %cl
-; AVX-NEXT:    negl %ecx
-; AVX-NEXT:    vmovd %ecx, %ymm2
-; AVX-NEXT:    vshufps $0, %ymm2, %ymm2, %ymm2
-; AVX-NEXT:    vmovaps %ymm2, %ymm2
-; AVX-NEXT:    vandps %ymm3, %ymm2, %ymm3
-; AVX-NEXT:    vandnps %ymm1, %ymm2, %ymm1
-; AVX-NEXT:    vorps %ymm1, %ymm3, %ymm1
-; AVX-NEXT:    vmovaps %ymm1, %ymm1
+; AVX-NEXT:    xorps %ymm5, %ymm5
+; AVX-NEXT:    vmovd %eax, %ymm5
+; AVX-NEXT:    vshufps $0, %ymm5, %ymm5, %ymm5
+; AVX-NEXT:    vmovaps %ymm5, %ymm4
+; AVX-NEXT:    andps %ymm0, %ymm5
+; AVX-NEXT:    andnps %ymm2, %ymm4
+; AVX-NEXT:    orps %ymm5, %ymm4
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
+; AVX-NEXT:    negl %eax
+; AVX-NEXT:    xorps %ymm0, %ymm0
+; AVX-NEXT:    vmovd %eax, %ymm0
+; AVX-NEXT:    vshufps $0, %ymm0, %ymm0, %ymm0
+; AVX-NEXT:    vmovaps %ymm0, %ymm2
+; AVX-NEXT:    andps %ymm1, %ymm0
+; AVX-NEXT:    andnps %ymm3, %ymm2
+; AVX-NEXT:    orps %ymm0, %ymm2
+; AVX-NEXT:    vmovaps %ymm4, %ymm0
+; AVX-NEXT:    vmovaps %ymm2, %ymm1
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v16f32:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb $1, %dil
-; AVX2-NEXT:    sete %al
-; AVX2-NEXT:    xorl %ecx, %ecx
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
 ; AVX2-NEXT:    negl %eax
-; AVX2-NEXT:    vmovd %eax, %ymm4
-; AVX2-NEXT:    vpshufd $0, %ymm4, %ymm4
-; AVX2-NEXT:    vmovdqa %ymm4, %ymm4
-; AVX2-NEXT:    vpand %ymm2, %ymm4, %ymm2
-; AVX2-NEXT:    vpandn %ymm0, %ymm4, %ymm0
-; AVX2-NEXT:    vpor %ymm0, %ymm2, %ymm0
-; AVX2-NEXT:    vmovdqa %ymm0, %ymm0
-; AVX2-NEXT:    sete %cl
-; AVX2-NEXT:    negl %ecx
-; AVX2-NEXT:    vmovd %ecx, %ymm2
-; AVX2-NEXT:    vpshufd $0, %ymm2, %ymm2
-; AVX2-NEXT:    vmovdqa %ymm2, %ymm2
-; AVX2-NEXT:    vpand %ymm3, %ymm2, %ymm3
-; AVX2-NEXT:    vpandn %ymm1, %ymm2, %ymm1
-; AVX2-NEXT:    vpor %ymm1, %ymm3, %ymm1
-; AVX2-NEXT:    vmovdqa %ymm1, %ymm1
+; AVX2-NEXT:    xorps %ymm5, %ymm5
+; AVX2-NEXT:    vmovd %eax, %ymm5
+; AVX2-NEXT:    vpshufd $0, %ymm5, %ymm5                # ymm5 = ymm5[0,0,0,0,4,4,4,4]
+; AVX2-NEXT:    vmovdqa %ymm5, %ymm4
+; AVX2-NEXT:    pand %ymm0, %ymm5
+; AVX2-NEXT:    pandn %ymm2, %ymm4
+; AVX2-NEXT:    por %ymm5, %ymm4
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
+; AVX2-NEXT:    negl %eax
+; AVX2-NEXT:    pxor %ymm0, %ymm0
+; AVX2-NEXT:    vmovd %eax, %ymm0
+; AVX2-NEXT:    vpshufd $0, %ymm0, %ymm0                # ymm0 = ymm0[0,0,0,0,4,4,4,4]
+; AVX2-NEXT:    vmovdqa %ymm0, %ymm2
+; AVX2-NEXT:    pand %ymm1, %ymm0
+; AVX2-NEXT:    pandn %ymm3, %ymm2
+; AVX2-NEXT:    por %ymm0, %ymm2
+; AVX2-NEXT:    vmovdqa %ymm4, %ymm0
+; AVX2-NEXT:    vmovdqa %ymm2, %ymm1
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v16f32:
@@ -741,97 +829,113 @@ define <16 x float> @test_ctselect_v16f32(i1 %cond, <16 x float> %a, <16 x float
 define <8 x i64> @test_ctselect_v8i64(i1 %cond, <8 x i64> %a, <8 x i64> %b) {
 ; SSE2-LABEL: test_ctselect_v8i64:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb $1, %dil
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
 ; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm8
-; SSE2-NEXT:    pshufd $0, %xmm8, %xmm8
-; SSE2-NEXT:    movdqa %xmm8, %xmm8
-; SSE2-NEXT:    pand %xmm8, %xmm4
-; SSE2-NEXT:    pandn %xmm0, %xmm8
-; SSE2-NEXT:    por %xmm4, %xmm8
+; SSE2-NEXT:    xorps %xmm9, %xmm9
+; SSE2-NEXT:    movd %eax, %xmm9
+; SSE2-NEXT:    pshufd $0, %xmm9, %xmm9
+; SSE2-NEXT:    movdqa %xmm9, %xmm8
+; SSE2-NEXT:    pand %xmm0, %xmm9
+; SSE2-NEXT:    pandn %xmm4, %xmm8
+; SSE2-NEXT:    por %xmm9, %xmm8
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm4
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    pandn %xmm5, %xmm4
+; SSE2-NEXT:    por %xmm0, %xmm4
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm5
+; SSE2-NEXT:    pand %xmm2, %xmm0
+; SSE2-NEXT:    pandn %xmm6, %xmm5
+; SSE2-NEXT:    por %xmm0, %xmm5
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm6
+; SSE2-NEXT:    pand %xmm3, %xmm0
+; SSE2-NEXT:    pandn %xmm7, %xmm6
+; SSE2-NEXT:    por %xmm0, %xmm6
 ; SSE2-NEXT:    movdqa %xmm8, %xmm0
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    xorl %eax, %eax
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    pandn %xmm1, %xmm4
-; SSE2-NEXT:    por %xmm5, %xmm4
 ; SSE2-NEXT:    movdqa %xmm4, %xmm1
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
-; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm6
-; SSE2-NEXT:    pandn %xmm2, %xmm4
-; SSE2-NEXT:    por %xmm6, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm2
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm7
-; SSE2-NEXT:    pandn %xmm3, %xmm4
-; SSE2-NEXT:    por %xmm7, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm3
+; SSE2-NEXT:    movdqa %xmm5, %xmm2
+; SSE2-NEXT:    movdqa %xmm6, %xmm3
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v8i64:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    xorl %eax, %eax
 ; AVX-NEXT:    testb $1, %dil
-; AVX-NEXT:    sete %al
-; AVX-NEXT:    xorl %ecx, %ecx
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
 ; AVX-NEXT:    negl %eax
-; AVX-NEXT:    vmovd %eax, %ymm4
-; AVX-NEXT:    vshufpd $0, %ymm4, %ymm4, %ymm4
-; AVX-NEXT:    vmovapd %ymm4, %ymm4
-; AVX-NEXT:    vandpd %ymm2, %ymm4, %ymm2
-; AVX-NEXT:    vandnpd %ymm0, %ymm4, %ymm0
-; AVX-NEXT:    vorpd %ymm0, %ymm2, %ymm0
-; AVX-NEXT:    vmovapd %ymm0, %ymm0
-; AVX-NEXT:    sete %cl
-; AVX-NEXT:    negl %ecx
-; AVX-NEXT:    vmovd %ecx, %ymm2
-; AVX-NEXT:    vshufpd $0, %ymm2, %ymm2, %ymm2
-; AVX-NEXT:    vmovapd %ymm2, %ymm2
-; AVX-NEXT:    vandpd %ymm3, %ymm2, %ymm3
-; AVX-NEXT:    vandnpd %ymm1, %ymm2, %ymm1
-; AVX-NEXT:    vorpd %ymm1, %ymm3, %ymm1
-; AVX-NEXT:    vmovapd %ymm1, %ymm1
+; AVX-NEXT:    xorps %ymm5, %ymm5
+; AVX-NEXT:    vmovd %eax, %ymm5
+; AVX-NEXT:    vshufpd $0, %ymm5, %ymm5, %ymm5
+; AVX-NEXT:    vmovapd %ymm5, %ymm4
+; AVX-NEXT:    andpd %ymm0, %ymm5
+; AVX-NEXT:    andnpd %ymm2, %ymm4
+; AVX-NEXT:    orpd %ymm5, %ymm4
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
+; AVX-NEXT:    negl %eax
+; AVX-NEXT:    xorpd %ymm0, %ymm0
+; AVX-NEXT:    vmovd %eax, %ymm0
+; AVX-NEXT:    vshufpd $0, %ymm0, %ymm0, %ymm0
+; AVX-NEXT:    vmovapd %ymm0, %ymm2
+; AVX-NEXT:    andpd %ymm1, %ymm0
+; AVX-NEXT:    andnpd %ymm3, %ymm2
+; AVX-NEXT:    orpd %ymm0, %ymm2
+; AVX-NEXT:    vmovapd %ymm4, %ymm0
+; AVX-NEXT:    vmovapd %ymm2, %ymm1
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v8i64:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb $1, %dil
-; AVX2-NEXT:    sete %al
-; AVX2-NEXT:    xorl %ecx, %ecx
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
 ; AVX2-NEXT:    negl %eax
-; AVX2-NEXT:    vmovd %eax, %ymm4
-; AVX2-NEXT:    vshufpd $0, %ymm4, %ymm4, %ymm4
-; AVX2-NEXT:    vmovapd %ymm4, %ymm4
-; AVX2-NEXT:    vandpd %ymm2, %ymm4, %ymm2
-; AVX2-NEXT:    vandnpd %ymm0, %ymm4, %ymm0
-; AVX2-NEXT:    vorpd %ymm0, %ymm2, %ymm0
-; AVX2-NEXT:    vmovapd %ymm0, %ymm0
-; AVX2-NEXT:    sete %cl
-; AVX2-NEXT:    negl %ecx
-; AVX2-NEXT:    vmovd %ecx, %ymm2
-; AVX2-NEXT:    vshufpd $0, %ymm2, %ymm2, %ymm2
-; AVX2-NEXT:    vmovapd %ymm2, %ymm2
-; AVX2-NEXT:    vandpd %ymm3, %ymm2, %ymm3
-; AVX2-NEXT:    vandnpd %ymm1, %ymm2, %ymm1
-; AVX2-NEXT:    vorpd %ymm1, %ymm3, %ymm1
-; AVX2-NEXT:    vmovapd %ymm1, %ymm1
+; AVX2-NEXT:    xorps %ymm5, %ymm5
+; AVX2-NEXT:    vmovd %eax, %ymm5
+; AVX2-NEXT:    vshufpd $0, %ymm5, %ymm5, %ymm5         # ymm5 = ymm5[0,0,2,2]
+; AVX2-NEXT:    vmovapd %ymm5, %ymm4
+; AVX2-NEXT:    andpd %ymm0, %ymm5
+; AVX2-NEXT:    andnpd %ymm2, %ymm4
+; AVX2-NEXT:    orpd %ymm5, %ymm4
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
+; AVX2-NEXT:    negl %eax
+; AVX2-NEXT:    xorpd %ymm0, %ymm0
+; AVX2-NEXT:    vmovd %eax, %ymm0
+; AVX2-NEXT:    vshufpd $0, %ymm0, %ymm0, %ymm0         # ymm0 = ymm0[0,0,2,2]
+; AVX2-NEXT:    vmovapd %ymm0, %ymm2
+; AVX2-NEXT:    andpd %ymm1, %ymm0
+; AVX2-NEXT:    andnpd %ymm3, %ymm2
+; AVX2-NEXT:    orpd %ymm0, %ymm2
+; AVX2-NEXT:    vmovapd %ymm4, %ymm0
+; AVX2-NEXT:    vmovapd %ymm2, %ymm1
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v8i64:
@@ -850,97 +954,113 @@ define <8 x i64> @test_ctselect_v8i64(i1 %cond, <8 x i64> %a, <8 x i64> %b) {
 define <8 x double> @test_ctselect_v8f64(i1 %cond, <8 x double> %a, <8 x double> %b) {
 ; SSE2-LABEL: test_ctselect_v8f64:
 ; SSE2:       # %bb.0:
-; SSE2-NEXT:    xorl %eax, %eax
 ; SSE2-NEXT:    testb $1, %dil
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
 ; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm8
-; SSE2-NEXT:    pshufd $0, %xmm8, %xmm8
-; SSE2-NEXT:    movdqa %xmm8, %xmm8
-; SSE2-NEXT:    pand %xmm8, %xmm4
-; SSE2-NEXT:    pandn %xmm0, %xmm8
-; SSE2-NEXT:    por %xmm4, %xmm8
+; SSE2-NEXT:    xorps %xmm9, %xmm9
+; SSE2-NEXT:    movd %eax, %xmm9
+; SSE2-NEXT:    pshufd $0, %xmm9, %xmm9
+; SSE2-NEXT:    movdqa %xmm9, %xmm8
+; SSE2-NEXT:    pand %xmm0, %xmm9
+; SSE2-NEXT:    pandn %xmm4, %xmm8
+; SSE2-NEXT:    por %xmm9, %xmm8
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm4
+; SSE2-NEXT:    pand %xmm1, %xmm0
+; SSE2-NEXT:    pandn %xmm5, %xmm4
+; SSE2-NEXT:    por %xmm0, %xmm4
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm5
+; SSE2-NEXT:    pand %xmm2, %xmm0
+; SSE2-NEXT:    pandn %xmm6, %xmm5
+; SSE2-NEXT:    por %xmm0, %xmm5
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    pxor %xmm0, %xmm0
+; SSE2-NEXT:    movd %eax, %xmm0
+; SSE2-NEXT:    pshufd $0, %xmm0, %xmm0
+; SSE2-NEXT:    movdqa %xmm0, %xmm6
+; SSE2-NEXT:    pand %xmm3, %xmm0
+; SSE2-NEXT:    pandn %xmm7, %xmm6
+; SSE2-NEXT:    por %xmm0, %xmm6
 ; SSE2-NEXT:    movdqa %xmm8, %xmm0
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    xorl %eax, %eax
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm5
-; SSE2-NEXT:    pandn %xmm1, %xmm4
-; SSE2-NEXT:    por %xmm5, %xmm4
 ; SSE2-NEXT:    movdqa %xmm4, %xmm1
-; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
-; SSE2-NEXT:    negl %eax
-; SSE2-NEXT:    movd %eax, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm6
-; SSE2-NEXT:    pandn %xmm2, %xmm4
-; SSE2-NEXT:    por %xmm6, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm2
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm4
-; SSE2-NEXT:    pshufd $0, %xmm4, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm4
-; SSE2-NEXT:    pand %xmm4, %xmm7
-; SSE2-NEXT:    pandn %xmm3, %xmm4
-; SSE2-NEXT:    por %xmm7, %xmm4
-; SSE2-NEXT:    movdqa %xmm4, %xmm3
+; SSE2-NEXT:    movdqa %xmm5, %xmm2
+; SSE2-NEXT:    movdqa %xmm6, %xmm3
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v8f64:
 ; AVX:       # %bb.0:
-; AVX-NEXT:    xorl %eax, %eax
 ; AVX-NEXT:    testb $1, %dil
-; AVX-NEXT:    sete %al
-; AVX-NEXT:    xorl %ecx, %ecx
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
 ; AVX-NEXT:    negl %eax
-; AVX-NEXT:    vmovd %eax, %ymm4
-; AVX-NEXT:    vshufpd $0, %ymm4, %ymm4, %ymm4
-; AVX-NEXT:    vmovapd %ymm4, %ymm4
-; AVX-NEXT:    vandpd %ymm2, %ymm4, %ymm2
-; AVX-NEXT:    vandnpd %ymm0, %ymm4, %ymm0
-; AVX-NEXT:    vorpd %ymm0, %ymm2, %ymm0
-; AVX-NEXT:    vmovapd %ymm0, %ymm0
-; AVX-NEXT:    sete %cl
-; AVX-NEXT:    negl %ecx
-; AVX-NEXT:    vmovd %ecx, %ymm2
-; AVX-NEXT:    vshufpd $0, %ymm2, %ymm2, %ymm2
-; AVX-NEXT:    vmovapd %ymm2, %ymm2
-; AVX-NEXT:    vandpd %ymm3, %ymm2, %ymm3
-; AVX-NEXT:    vandnpd %ymm1, %ymm2, %ymm1
-; AVX-NEXT:    vorpd %ymm1, %ymm3, %ymm1
-; AVX-NEXT:    vmovapd %ymm1, %ymm1
+; AVX-NEXT:    xorps %ymm5, %ymm5
+; AVX-NEXT:    vmovd %eax, %ymm5
+; AVX-NEXT:    vshufpd $0, %ymm5, %ymm5, %ymm5
+; AVX-NEXT:    vmovapd %ymm5, %ymm4
+; AVX-NEXT:    andpd %ymm0, %ymm5
+; AVX-NEXT:    andnpd %ymm2, %ymm4
+; AVX-NEXT:    orpd %ymm5, %ymm4
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
+; AVX-NEXT:    negl %eax
+; AVX-NEXT:    xorpd %ymm0, %ymm0
+; AVX-NEXT:    vmovd %eax, %ymm0
+; AVX-NEXT:    vshufpd $0, %ymm0, %ymm0, %ymm0
+; AVX-NEXT:    vmovapd %ymm0, %ymm2
+; AVX-NEXT:    andpd %ymm1, %ymm0
+; AVX-NEXT:    andnpd %ymm3, %ymm2
+; AVX-NEXT:    orpd %ymm0, %ymm2
+; AVX-NEXT:    vmovapd %ymm4, %ymm0
+; AVX-NEXT:    vmovapd %ymm2, %ymm1
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v8f64:
 ; AVX2:       # %bb.0:
-; AVX2-NEXT:    xorl %eax, %eax
 ; AVX2-NEXT:    testb $1, %dil
-; AVX2-NEXT:    sete %al
-; AVX2-NEXT:    xorl %ecx, %ecx
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
 ; AVX2-NEXT:    negl %eax
-; AVX2-NEXT:    vmovd %eax, %ymm4
-; AVX2-NEXT:    vshufpd $0, %ymm4, %ymm4, %ymm4
-; AVX2-NEXT:    vmovapd %ymm4, %ymm4
-; AVX2-NEXT:    vandpd %ymm2, %ymm4, %ymm2
-; AVX2-NEXT:    vandnpd %ymm0, %ymm4, %ymm0
-; AVX2-NEXT:    vorpd %ymm0, %ymm2, %ymm0
-; AVX2-NEXT:    vmovapd %ymm0, %ymm0
-; AVX2-NEXT:    sete %cl
-; AVX2-NEXT:    negl %ecx
-; AVX2-NEXT:    vmovd %ecx, %ymm2
-; AVX2-NEXT:    vshufpd $0, %ymm2, %ymm2, %ymm2
-; AVX2-NEXT:    vmovapd %ymm2, %ymm2
-; AVX2-NEXT:    vandpd %ymm3, %ymm2, %ymm3
-; AVX2-NEXT:    vandnpd %ymm1, %ymm2, %ymm1
-; AVX2-NEXT:    vorpd %ymm1, %ymm3, %ymm1
-; AVX2-NEXT:    vmovapd %ymm1, %ymm1
+; AVX2-NEXT:    xorps %ymm5, %ymm5
+; AVX2-NEXT:    vmovd %eax, %ymm5
+; AVX2-NEXT:    vshufpd $0, %ymm5, %ymm5, %ymm5         # ymm5 = ymm5[0,0,2,2]
+; AVX2-NEXT:    vmovapd %ymm5, %ymm4
+; AVX2-NEXT:    andpd %ymm0, %ymm5
+; AVX2-NEXT:    andnpd %ymm2, %ymm4
+; AVX2-NEXT:    orpd %ymm5, %ymm4
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
+; AVX2-NEXT:    negl %eax
+; AVX2-NEXT:    xorpd %ymm0, %ymm0
+; AVX2-NEXT:    vmovd %eax, %ymm0
+; AVX2-NEXT:    vshufpd $0, %ymm0, %ymm0, %ymm0         # ymm0 = ymm0[0,0,2,2]
+; AVX2-NEXT:    vmovapd %ymm0, %ymm2
+; AVX2-NEXT:    andpd %ymm1, %ymm0
+; AVX2-NEXT:    andnpd %ymm3, %ymm2
+; AVX2-NEXT:    orpd %ymm0, %ymm2
+; AVX2-NEXT:    vmovapd %ymm4, %ymm0
+; AVX2-NEXT:    vmovapd %ymm2, %ymm1
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v8f64:
@@ -961,49 +1081,55 @@ define <4 x i32> @test_ctselect_v4i32_const_true(<4 x i32> %a, <4 x i32> %b) {
 ; SSE2-LABEL: test_ctselect_v4i32_const_true:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    movb $1, %al
-; SSE2-NEXT:    xorl %ecx, %ecx
 ; SSE2-NEXT:    testb %al, %al
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm2
-; SSE2-NEXT:    pshufd $0, %xmm2, %xmm2
-; SSE2-NEXT:    movdqa %xmm2, %xmm2
-; SSE2-NEXT:    pand %xmm2, %xmm1
-; SSE2-NEXT:    pandn %xmm0, %xmm2
-; SSE2-NEXT:    por %xmm1, %xmm2
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    xorps %xmm3, %xmm3
+; SSE2-NEXT:    movd %eax, %xmm3
+; SSE2-NEXT:    pshufd $0, %xmm3, %xmm3
+; SSE2-NEXT:    movdqa %xmm3, %xmm2
+; SSE2-NEXT:    pand %xmm0, %xmm3
+; SSE2-NEXT:    pandn %xmm1, %xmm2
+; SSE2-NEXT:    por %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm0
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v4i32_const_true:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    movb $1, %al
-; AVX-NEXT:    xorl %ecx, %ecx
 ; AVX-NEXT:    testb %al, %al
-; AVX-NEXT:    sete %cl
-; AVX-NEXT:    negl %ecx
-; AVX-NEXT:    movd %ecx, %xmm2
-; AVX-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm2
-; AVX-NEXT:    pand %xmm2, %xmm1
-; AVX-NEXT:    pandn %xmm0, %xmm2
-; AVX-NEXT:    por %xmm1, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm0
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
+; AVX-NEXT:    negl %eax
+; AVX-NEXT:    xorps %xmm3, %xmm3
+; AVX-NEXT:    movd %eax, %xmm3
+; AVX-NEXT:    pshufd $0, %xmm3, %xmm3
+; AVX-NEXT:    movdqa %xmm3, %xmm2
+; AVX-NEXT:    pand %xmm0, %xmm3
+; AVX-NEXT:    pandn %xmm1, %xmm2
+; AVX-NEXT:    por %xmm3, %xmm2
+; AVX-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v4i32_const_true:
 ; AVX2:       # %bb.0:
 ; AVX2-NEXT:    movb $1, %al
-; AVX2-NEXT:    xorl %ecx, %ecx
 ; AVX2-NEXT:    testb %al, %al
-; AVX2-NEXT:    sete %cl
-; AVX2-NEXT:    negl %ecx
-; AVX2-NEXT:    movd %ecx, %xmm2
-; AVX2-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm2
-; AVX2-NEXT:    pand %xmm2, %xmm1
-; AVX2-NEXT:    pandn %xmm0, %xmm2
-; AVX2-NEXT:    por %xmm1, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm0
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
+; AVX2-NEXT:    negl %eax
+; AVX2-NEXT:    xorps %xmm3, %xmm3
+; AVX2-NEXT:    movd %eax, %xmm3
+; AVX2-NEXT:    pshufd $0, %xmm3, %xmm3                # xmm3 = xmm3[0,0,0,0]
+; AVX2-NEXT:    movdqa %xmm3, %xmm2
+; AVX2-NEXT:    pand %xmm0, %xmm3
+; AVX2-NEXT:    pandn %xmm1, %xmm2
+; AVX2-NEXT:    por %xmm3, %xmm2
+; AVX2-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v4i32_const_true:
@@ -1017,49 +1143,55 @@ define <4 x i32> @test_ctselect_v4i32_const_false(<4 x i32> %a, <4 x i32> %b) {
 ; SSE2-LABEL: test_ctselect_v4i32_const_false:
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    xorl %eax, %eax
-; SSE2-NEXT:    xorl %ecx, %ecx
 ; SSE2-NEXT:    testb %al, %al
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm2
-; SSE2-NEXT:    pshufd $0, %xmm2, %xmm2
-; SSE2-NEXT:    movdqa %xmm2, %xmm2
-; SSE2-NEXT:    pand %xmm2, %xmm1
-; SSE2-NEXT:    pandn %xmm0, %xmm2
-; SSE2-NEXT:    por %xmm1, %xmm2
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    xorps %xmm3, %xmm3
+; SSE2-NEXT:    movd %eax, %xmm3
+; SSE2-NEXT:    pshufd $0, %xmm3, %xmm3
+; SSE2-NEXT:    movdqa %xmm3, %xmm2
+; SSE2-NEXT:    pand %xmm0, %xmm3
+; SSE2-NEXT:    pandn %xmm1, %xmm2
+; SSE2-NEXT:    por %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm0
 ; SSE2-NEXT:    retq
 ;
 ; AVX-LABEL: test_ctselect_v4i32_const_false:
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    xorl %eax, %eax
-; AVX-NEXT:    xorl %ecx, %ecx
 ; AVX-NEXT:    testb %al, %al
-; AVX-NEXT:    sete %cl
-; AVX-NEXT:    negl %ecx
-; AVX-NEXT:    movd %ecx, %xmm2
-; AVX-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm2
-; AVX-NEXT:    pand %xmm2, %xmm1
-; AVX-NEXT:    pandn %xmm0, %xmm2
-; AVX-NEXT:    por %xmm1, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm0
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
+; AVX-NEXT:    negl %eax
+; AVX-NEXT:    xorps %xmm3, %xmm3
+; AVX-NEXT:    movd %eax, %xmm3
+; AVX-NEXT:    pshufd $0, %xmm3, %xmm3
+; AVX-NEXT:    movdqa %xmm3, %xmm2
+; AVX-NEXT:    pand %xmm0, %xmm3
+; AVX-NEXT:    pandn %xmm1, %xmm2
+; AVX-NEXT:    por %xmm3, %xmm2
+; AVX-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v4i32_const_false:
 ; AVX2:       # %bb.0:
 ; AVX2-NEXT:    xorl %eax, %eax
-; AVX2-NEXT:    xorl %ecx, %ecx
 ; AVX2-NEXT:    testb %al, %al
-; AVX2-NEXT:    sete %cl
-; AVX2-NEXT:    negl %ecx
-; AVX2-NEXT:    movd %ecx, %xmm2
-; AVX2-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm2
-; AVX2-NEXT:    pand %xmm2, %xmm1
-; AVX2-NEXT:    pandn %xmm0, %xmm2
-; AVX2-NEXT:    por %xmm1, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm0
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
+; AVX2-NEXT:    negl %eax
+; AVX2-NEXT:    xorps %xmm3, %xmm3
+; AVX2-NEXT:    movd %eax, %xmm3
+; AVX2-NEXT:    pshufd $0, %xmm3, %xmm3                # xmm3 = xmm3[0,0,0,0]
+; AVX2-NEXT:    movdqa %xmm3, %xmm2
+; AVX2-NEXT:    pand %xmm0, %xmm3
+; AVX2-NEXT:    pandn %xmm1, %xmm2
+; AVX2-NEXT:    por %xmm3, %xmm2
+; AVX2-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v4i32_const_false:
@@ -1076,16 +1208,18 @@ define <4 x i32> @test_ctselect_v4i32_icmp(i32 %x, i32 %y, <4 x i32> %a, <4 x i3
 ; SSE2:       # %bb.0:
 ; SSE2-NEXT:    cmpl %esi, %edi
 ; SSE2-NEXT:    sete %al
-; SSE2-NEXT:    xorl %ecx, %ecx
 ; SSE2-NEXT:    testb %al, %al
-; SSE2-NEXT:    sete %cl
-; SSE2-NEXT:    negl %ecx
-; SSE2-NEXT:    movd %ecx, %xmm2
-; SSE2-NEXT:    pshufd $0, %xmm2, %xmm2
-; SSE2-NEXT:    movdqa %xmm2, %xmm2
-; SSE2-NEXT:    pand %xmm2, %xmm1
-; SSE2-NEXT:    pandn %xmm0, %xmm2
-; SSE2-NEXT:    por %xmm1, %xmm2
+; SSE2-NEXT:    movl $0, %eax
+; SSE2-NEXT:    setne %al
+; SSE2-NEXT:    movzbl %al, %eax
+; SSE2-NEXT:    negl %eax
+; SSE2-NEXT:    xorps %xmm3, %xmm3
+; SSE2-NEXT:    movd %eax, %xmm3
+; SSE2-NEXT:    pshufd $0, %xmm3, %xmm3
+; SSE2-NEXT:    movdqa %xmm3, %xmm2
+; SSE2-NEXT:    pand %xmm0, %xmm3
+; SSE2-NEXT:    pandn %xmm1, %xmm2
+; SSE2-NEXT:    por %xmm3, %xmm2
 ; SSE2-NEXT:    movdqa %xmm2, %xmm0
 ; SSE2-NEXT:    retq
 ;
@@ -1093,34 +1227,38 @@ define <4 x i32> @test_ctselect_v4i32_icmp(i32 %x, i32 %y, <4 x i32> %a, <4 x i3
 ; AVX:       # %bb.0:
 ; AVX-NEXT:    cmpl %esi, %edi
 ; AVX-NEXT:    sete %al
-; AVX-NEXT:    xorl %ecx, %ecx
 ; AVX-NEXT:    testb %al, %al
-; AVX-NEXT:    sete %cl
-; AVX-NEXT:    negl %ecx
-; AVX-NEXT:    movd %ecx, %xmm2
-; AVX-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm2
-; AVX-NEXT:    pand %xmm2, %xmm1
-; AVX-NEXT:    pandn %xmm0, %xmm2
-; AVX-NEXT:    por %xmm1, %xmm2
-; AVX-NEXT:    movdqa %xmm2, %xmm0
+; AVX-NEXT:    movl $0, %eax
+; AVX-NEXT:    setne %al
+; AVX-NEXT:    movzbl %al, %eax
+; AVX-NEXT:    negl %eax
+; AVX-NEXT:    xorps %xmm3, %xmm3
+; AVX-NEXT:    movd %eax, %xmm3
+; AVX-NEXT:    pshufd $0, %xmm3, %xmm3
+; AVX-NEXT:    movdqa %xmm3, %xmm2
+; AVX-NEXT:    pand %xmm0, %xmm3
+; AVX-NEXT:    pandn %xmm1, %xmm2
+; AVX-NEXT:    por %xmm3, %xmm2
+; AVX-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX-NEXT:    retq
 ;
 ; AVX2-LABEL: test_ctselect_v4i32_icmp:
 ; AVX2:       # %bb.0:
 ; AVX2-NEXT:    cmpl %esi, %edi
 ; AVX2-NEXT:    sete %al
-; AVX2-NEXT:    xorl %ecx, %ecx
 ; AVX2-NEXT:    testb %al, %al
-; AVX2-NEXT:    sete %cl
-; AVX2-NEXT:    negl %ecx
-; AVX2-NEXT:    movd %ecx, %xmm2
-; AVX2-NEXT:    pshufd $0, %xmm2, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm2
-; AVX2-NEXT:    pand %xmm2, %xmm1
-; AVX2-NEXT:    pandn %xmm0, %xmm2
-; AVX2-NEXT:    por %xmm1, %xmm2
-; AVX2-NEXT:    movdqa %xmm2, %xmm0
+; AVX2-NEXT:    movl $0, %eax
+; AVX2-NEXT:    setne %al
+; AVX2-NEXT:    movzbl %al, %eax
+; AVX2-NEXT:    negl %eax
+; AVX2-NEXT:    xorps %xmm3, %xmm3
+; AVX2-NEXT:    movd %eax, %xmm3
+; AVX2-NEXT:    pshufd $0, %xmm3, %xmm3                # xmm3 = xmm3[0,0,0,0]
+; AVX2-NEXT:    movdqa %xmm3, %xmm2
+; AVX2-NEXT:    pand %xmm0, %xmm3
+; AVX2-NEXT:    pandn %xmm1, %xmm2
+; AVX2-NEXT:    por %xmm3, %xmm2
+; AVX2-NEXT:    vmovdqa %xmm2, %xmm0
 ; AVX2-NEXT:    retq
 ;
 ; AVX512-LABEL: test_ctselect_v4i32_icmp:

--- a/llvm/test/CodeGen/X86/ctselect.ll
+++ b/llvm/test/CodeGen/X86/ctselect.ll
@@ -10,7 +10,8 @@ define i8 @test_ctselect_i8(i1 %cond, i8 %a, i8 %b) {
 ; X64-NEXT:    movl %edx, %eax
 ; X64-NEXT:    testb $1, %dil
 ; X64-NEXT:    cmovnel %esi, %eax
-; X64:    retq
+; X64-NEXT:                                        # kill: def $al killed $al killed $eax
+; X64-NEXT:    retq
 ;
 ; X32-LABEL: test_ctselect_i8:
 ; X32:       # %bb.0:
@@ -28,7 +29,8 @@ define i16 @test_ctselect_i16(i1 %cond, i16 %a, i16 %b) {
 ; X64-NEXT:    movl %edx, %eax
 ; X64-NEXT:    testb $1, %dil
 ; X64-NEXT:    cmovnel %esi, %eax
-; X64:    retq
+; X64-NEXT:                                        # kill: def $ax killed $ax killed $eax
+; X64-NEXT:    retq
 ;
 ; X32-LABEL: test_ctselect_i16:
 ; X32:       # %bb.0:
@@ -289,10 +291,14 @@ define i32 @test_ctselect_icmp_ult(i32 %x, i32 %y, i32 %a, i32 %b) {
 define float @test_ctselect_fcmp_oeq(float %x, float %y, float %a, float %b) {
 ; X64-LABEL: test_ctselect_fcmp_oeq:
 ; X64:       # %bb.0:
-; X64-NEXT:    cmpeqss %xmm1, %xmm0
-; X64-NEXT:    andps %xmm0, %xmm2
-; X64-NEXT:    andnps %xmm3, %xmm0
-; X64-NEXT:    orps %xmm2, %xmm0
+; X64-NEXT:    movd %xmm2, %eax
+; X64-NEXT:    movd %xmm3, %ecx
+; X64-NEXT:    ucomiss %xmm1, %xmm0
+; X64-NEXT:    setnp %dl
+; X64-NEXT:    sete %sil
+; X64-NEXT:    testb %dl, %sil
+; X64-NEXT:    cmovnel %eax, %ecx
+; X64-NEXT:    movd %ecx, %xmm0
 ; X64-NEXT:    retq
 ;
 ; X32-LABEL: test_ctselect_fcmp_oeq:


### PR DESCRIPTION
Description:
The PR changes moves the expansion of `CTSELECT_*` pseudo instructions for vector types to target specific post RA expansion pass. After expansion it bundles the instructions setting up `NoMerge` flag and treated as atomic units. Unlike Pre-RA bundling, the solution is reliable through register allocation. It also pre-allocates the temp registers needed for expansion with table-gen `CTSELECT_*` definition, thus avoid allocating physical register afterwords.

Fixes https://github.com/trailofbits/llvm-ct-intrinsics/issues/16
