### PR TITLE
[CT][NFC] Generated Mips code-gen tests that's affected by DAG Chaining

### DIFF
--- a/llvm/test/CodeGen/Mips/ctselect-fallback-edge-cases.ll
+++ b/llvm/test/CodeGen/Mips/ctselect-fallback-edge-cases.ll
@@ -33,29 +33,29 @@ define i32 @test_ctselect_extremal_values(i1 %cond) {
 ; M32-LABEL: test_ctselect_extremal_values:
 ; M32:       # %bb.0:
 ; M32-NEXT:    andi $1, $4, 1
-; M32-NEXT:    lui $2, 32767
 ; M32-NEXT:    lui $3, 32768
+; M32-NEXT:    addiu $2, $1, -1
 ; M32-NEXT:    negu $1, $1
-; M32-NEXT:    ori $2, $2, 65535
-; M32-NEXT:    and $2, $1, $2
-; M32-NEXT:    not $1, $1
+; M32-NEXT:    and $2, $2, $3
+; M32-NEXT:    lui $3, 32767
+; M32-NEXT:    ori $3, $3, 65535
 ; M32-NEXT:    and $1, $1, $3
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_extremal_values:
 ; M64:       # %bb.0:
 ; M64-NEXT:    sll $1, $4, 0
-; M64-NEXT:    lui $2, 32767
 ; M64-NEXT:    lui $3, 32768
 ; M64-NEXT:    andi $1, $1, 1
-; M64-NEXT:    ori $2, $2, 65535
+; M64-NEXT:    addiu $2, $1, -1
 ; M64-NEXT:    negu $1, $1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
+; M64-NEXT:    and $2, $2, $3
+; M64-NEXT:    lui $3, 32767
+; M64-NEXT:    ori $3, $3, 65535
 ; M64-NEXT:    and $1, $1, $3
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    or $2, $2, $1
+; M64-NEXT:    or $2, $1, $2
   %result = call i32 @llvm.ct.select.i32(i1 %cond, i32 2147483647, i32 -2147483648)
   ret i32 %result
 }
@@ -84,23 +84,22 @@ define ptr @test_ctselect_function_ptr(i1 %cond, ptr %func1, ptr %func2) {
 ; M32-LABEL: test_ctselect_function_ptr:
 ; M32:       # %bb.0:
 ; M32-NEXT:    andi $1, $4, 1
+; M32-NEXT:    addiu $2, $1, -1
 ; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $5
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $6
+; M32-NEXT:    and $2, $2, $6
+; M32-NEXT:    and $1, $1, $5
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_function_ptr:
 ; M64:       # %bb.0:
 ; M64-NEXT:    andi $1, $4, 1
-; M64-NEXT:    daddiu $3, $zero, -1
+; M64-NEXT:    daddiu $2, $1, -1
 ; M64-NEXT:    dnegu $1, $1
-; M64-NEXT:    and $2, $1, $5
-; M64-NEXT:    xor $1, $1, $3
-; M64-NEXT:    and $1, $1, $6
+; M64-NEXT:    and $2, $2, $6
+; M64-NEXT:    and $1, $1, $5
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    or $2, $2, $1
+; M64-NEXT:    or $2, $1, $2
   %result = call ptr @llvm.ct.select.p0(i1 %cond, ptr %func1, ptr %func2)
   ret ptr %result
 }
@@ -111,12 +110,12 @@ define ptr @test_ctselect_ptr_cmp(ptr %p1, ptr %p2, ptr %a, ptr %b) {
 ; M32:       # %bb.0:
 ; M32-NEXT:    xor $1, $4, $5
 ; M32-NEXT:    sltu $1, $zero, $1
+; M32-NEXT:    negu $2, $1
 ; M32-NEXT:    addiu $1, $1, -1
-; M32-NEXT:    and $2, $1, $6
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $7
+; M32-NEXT:    and $2, $2, $7
+; M32-NEXT:    and $1, $1, $6
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_ptr_cmp:
 ; M64:       # %bb.0:
@@ -141,23 +140,22 @@ define ptr @test_ctselect_struct_ptr(i1 %cond, ptr %a, ptr %b) {
 ; M32-LABEL: test_ctselect_struct_ptr:
 ; M32:       # %bb.0:
 ; M32-NEXT:    andi $1, $4, 1
+; M32-NEXT:    addiu $2, $1, -1
 ; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $5
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $6
+; M32-NEXT:    and $2, $2, $6
+; M32-NEXT:    and $1, $1, $5
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_struct_ptr:
 ; M64:       # %bb.0:
 ; M64-NEXT:    andi $1, $4, 1
-; M64-NEXT:    daddiu $3, $zero, -1
+; M64-NEXT:    daddiu $2, $1, -1
 ; M64-NEXT:    dnegu $1, $1
-; M64-NEXT:    and $2, $1, $5
-; M64-NEXT:    xor $1, $1, $3
-; M64-NEXT:    and $1, $1, $6
+; M64-NEXT:    and $2, $2, $6
+; M64-NEXT:    and $1, $1, $5
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    or $2, $2, $1
+; M64-NEXT:    or $2, $1, $2
   %result = call ptr @llvm.ct.select.p0(i1 %cond, ptr %a, ptr %b)
   ret ptr %result
 }
@@ -167,70 +165,70 @@ define i32 @test_ctselect_deeply_nested(i1 %c1, i1 %c2, i1 %c3, i1 %c4, i32 %a, 
 ; M32-LABEL: test_ctselect_deeply_nested:
 ; M32:       # %bb.0:
 ; M32-NEXT:    andi $1, $4, 1
-; M32-NEXT:    lw $2, 16($sp)
 ; M32-NEXT:    lw $3, 20($sp)
-; M32-NEXT:    lw $4, 24($sp)
+; M32-NEXT:    addiu $2, $1, -1
 ; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $2
-; M32-NEXT:    not $1, $1
+; M32-NEXT:    and $2, $2, $3
+; M32-NEXT:    lw $3, 16($sp)
 ; M32-NEXT:    and $1, $1, $3
-; M32-NEXT:    or $1, $2, $1
+; M32-NEXT:    or $1, $1, $2
 ; M32-NEXT:    andi $2, $5, 1
-; M32-NEXT:    negu $2, $2
-; M32-NEXT:    not $3, $2
-; M32-NEXT:    and $1, $2, $1
-; M32-NEXT:    and $2, $3, $4
-; M32-NEXT:    andi $4, $6, 1
-; M32-NEXT:    andi $3, $7, 1
-; M32-NEXT:    lw $6, 32($sp)
-; M32-NEXT:    negu $4, $4
-; M32-NEXT:    or $1, $1, $2
-; M32-NEXT:    negu $3, $3
-; M32-NEXT:    and $1, $4, $1
-; M32-NEXT:    not $2, $4
-; M32-NEXT:    lw $4, 28($sp)
-; M32-NEXT:    not $5, $3
-; M32-NEXT:    and $2, $2, $4
-; M32-NEXT:    or $1, $1, $2
-; M32-NEXT:    and $2, $5, $6
+; M32-NEXT:    negu $3, $2
+; M32-NEXT:    addiu $2, $2, -1
 ; M32-NEXT:    and $1, $3, $1
+; M32-NEXT:    lw $3, 24($sp)
+; M32-NEXT:    and $2, $2, $3
+; M32-NEXT:    andi $3, $7, 1
+; M32-NEXT:    or $1, $1, $2
+; M32-NEXT:    andi $2, $6, 1
+; M32-NEXT:    lw $6, 32($sp)
+; M32-NEXT:    negu $4, $3
+; M32-NEXT:    addiu $3, $3, -1
+; M32-NEXT:    negu $5, $2
+; M32-NEXT:    addiu $2, $2, -1
+; M32-NEXT:    and $1, $5, $1
+; M32-NEXT:    lw $5, 28($sp)
+; M32-NEXT:    and $2, $2, $5
+; M32-NEXT:    or $1, $1, $2
+; M32-NEXT:    and $2, $3, $6
+; M32-NEXT:    and $1, $4, $1
 ; M32-NEXT:    jr $ra
 ; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_deeply_nested:
 ; M64:       # %bb.0:
 ; M64-NEXT:    sll $1, $4, 0
-; M64-NEXT:    sll $2, $7, 0
-; M64-NEXT:    sll $5, $5, 0
 ; M64-NEXT:    sll $4, $9, 0
-; M64-NEXT:    sll $7, $8, 0
+; M64-NEXT:    sll $3, $8, 0
+; M64-NEXT:    sll $8, $11, 0
+; M64-NEXT:    lw $9, 0($sp)
 ; M64-NEXT:    andi $1, $1, 1
-; M64-NEXT:    andi $5, $5, 1
-; M64-NEXT:    andi $2, $2, 1
-; M64-NEXT:    negu $1, $1
-; M64-NEXT:    negu $5, $5
-; M64-NEXT:    negu $2, $2
-; M64-NEXT:    not $3, $1
-; M64-NEXT:    and $1, $1, $7
-; M64-NEXT:    lw $7, 0($sp)
-; M64-NEXT:    and $3, $3, $4
-; M64-NEXT:    sll $4, $6, 0
-; M64-NEXT:    not $6, $2
-; M64-NEXT:    or $1, $1, $3
-; M64-NEXT:    not $3, $5
+; M64-NEXT:    negu $2, $1
+; M64-NEXT:    addiu $1, $1, -1
+; M64-NEXT:    and $1, $1, $4
+; M64-NEXT:    sll $4, $5, 0
+; M64-NEXT:    and $2, $2, $3
+; M64-NEXT:    sll $3, $6, 0
+; M64-NEXT:    sll $5, $7, 0
 ; M64-NEXT:    andi $4, $4, 1
-; M64-NEXT:    and $1, $5, $1
-; M64-NEXT:    sll $5, $10, 0
-; M64-NEXT:    negu $4, $4
-; M64-NEXT:    and $3, $3, $5
-; M64-NEXT:    or $1, $1, $3
-; M64-NEXT:    not $3, $4
-; M64-NEXT:    and $1, $4, $1
-; M64-NEXT:    sll $4, $11, 0
-; M64-NEXT:    and $3, $3, $4
-; M64-NEXT:    or $1, $1, $3
+; M64-NEXT:    or $1, $2, $1
+; M64-NEXT:    andi $3, $3, 1
+; M64-NEXT:    andi $5, $5, 1
+; M64-NEXT:    negu $2, $4
+; M64-NEXT:    addiu $4, $4, -1
+; M64-NEXT:    negu $7, $3
+; M64-NEXT:    negu $6, $5
+; M64-NEXT:    addiu $5, $5, -1
 ; M64-NEXT:    and $1, $2, $1
-; M64-NEXT:    and $2, $6, $7
+; M64-NEXT:    sll $2, $10, 0
+; M64-NEXT:    and $2, $4, $2
+; M64-NEXT:    or $1, $1, $2
+; M64-NEXT:    addiu $2, $3, -1
+; M64-NEXT:    and $1, $7, $1
+; M64-NEXT:    and $2, $2, $8
+; M64-NEXT:    or $1, $1, $2
+; M64-NEXT:    and $2, $5, $9
+; M64-NEXT:    and $1, $6, $1
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    or $2, $1, $2
   %sel1 = call i32 @llvm.ct.select.i32(i1 %c1, i32 %a, i32 %b)

--- a/llvm/test/CodeGen/Mips/ctselect-fallback-patterns.ll
+++ b/llvm/test/CodeGen/Mips/ctselect-fallback-patterns.ll
@@ -26,17 +26,16 @@ define i32 @test_ctselect_smax_zero(i32 %x) {
 ; M32-LABEL: test_ctselect_smax_zero:
 ; M32:       # %bb.0:
 ; M32-NEXT:    slti $1, $4, 1
-; M32-NEXT:    addiu $1, $1, -1
+; M32-NEXT:    movn $4, $zero, $1
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    and $2, $1, $4
+; M32-NEXT:    move $2, $4
 ;
 ; M64-LABEL: test_ctselect_smax_zero:
 ; M64:       # %bb.0:
-; M64-NEXT:    sll $1, $4, 0
-; M64-NEXT:    slti $2, $1, 1
-; M64-NEXT:    addiu $2, $2, -1
+; M64-NEXT:    sll $2, $4, 0
+; M64-NEXT:    slti $1, $2, 1
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    and $2, $2, $1
+; M64-NEXT:    movn $2, $zero, $1
   %cmp = icmp sgt i32 %x, 0
   %result = call i32 @llvm.ct.select.i32(i1 %cmp, i32 %x, i32 0)
   ret i32 %result
@@ -48,12 +47,12 @@ define i32 @test_ctselect_smin_generic(i32 %x, i32 %y) {
 ; M32:       # %bb.0:
 ; M32-NEXT:    slt $1, $4, $5
 ; M32-NEXT:    xori $1, $1, 1
+; M32-NEXT:    negu $2, $1
 ; M32-NEXT:    addiu $1, $1, -1
-; M32-NEXT:    and $2, $1, $4
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $5
+; M32-NEXT:    and $2, $2, $5
+; M32-NEXT:    and $1, $1, $4
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_smin_generic:
 ; M64:       # %bb.0:
@@ -61,10 +60,10 @@ define i32 @test_ctselect_smin_generic(i32 %x, i32 %y) {
 ; M64-NEXT:    sll $2, $4, 0
 ; M64-NEXT:    slt $3, $2, $1
 ; M64-NEXT:    xori $3, $3, 1
+; M64-NEXT:    negu $4, $3
 ; M64-NEXT:    addiu $3, $3, -1
+; M64-NEXT:    and $1, $4, $1
 ; M64-NEXT:    and $2, $3, $2
-; M64-NEXT:    not $3, $3
-; M64-NEXT:    and $1, $3, $1
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    or $2, $2, $1
   %cmp = icmp slt i32 %x, %y
@@ -78,12 +77,12 @@ define i32 @test_ctselect_smax_generic(i32 %x, i32 %y) {
 ; M32:       # %bb.0:
 ; M32-NEXT:    slt $1, $5, $4
 ; M32-NEXT:    xori $1, $1, 1
+; M32-NEXT:    negu $2, $1
 ; M32-NEXT:    addiu $1, $1, -1
-; M32-NEXT:    and $2, $1, $4
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $5
+; M32-NEXT:    and $2, $2, $5
+; M32-NEXT:    and $1, $1, $4
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_smax_generic:
 ; M64:       # %bb.0:
@@ -91,10 +90,10 @@ define i32 @test_ctselect_smax_generic(i32 %x, i32 %y) {
 ; M64-NEXT:    sll $2, $5, 0
 ; M64-NEXT:    slt $3, $2, $1
 ; M64-NEXT:    xori $3, $3, 1
+; M64-NEXT:    negu $4, $3
 ; M64-NEXT:    addiu $3, $3, -1
+; M64-NEXT:    and $2, $4, $2
 ; M64-NEXT:    and $1, $3, $1
-; M64-NEXT:    not $3, $3
-; M64-NEXT:    and $2, $3, $2
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    or $2, $1, $2
   %cmp = icmp sgt i32 %x, %y
@@ -108,12 +107,12 @@ define i32 @test_ctselect_umin_generic(i32 %x, i32 %y) {
 ; M32:       # %bb.0:
 ; M32-NEXT:    sltu $1, $4, $5
 ; M32-NEXT:    xori $1, $1, 1
+; M32-NEXT:    negu $2, $1
 ; M32-NEXT:    addiu $1, $1, -1
-; M32-NEXT:    and $2, $1, $4
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $5
+; M32-NEXT:    and $2, $2, $5
+; M32-NEXT:    and $1, $1, $4
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_umin_generic:
 ; M64:       # %bb.0:
@@ -121,10 +120,10 @@ define i32 @test_ctselect_umin_generic(i32 %x, i32 %y) {
 ; M64-NEXT:    sll $2, $4, 0
 ; M64-NEXT:    sltu $3, $2, $1
 ; M64-NEXT:    xori $3, $3, 1
+; M64-NEXT:    negu $4, $3
 ; M64-NEXT:    addiu $3, $3, -1
+; M64-NEXT:    and $1, $4, $1
 ; M64-NEXT:    and $2, $3, $2
-; M64-NEXT:    not $3, $3
-; M64-NEXT:    and $1, $3, $1
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    or $2, $2, $1
   %cmp = icmp ult i32 %x, %y
@@ -138,12 +137,12 @@ define i32 @test_ctselect_umax_generic(i32 %x, i32 %y) {
 ; M32:       # %bb.0:
 ; M32-NEXT:    sltu $1, $5, $4
 ; M32-NEXT:    xori $1, $1, 1
+; M32-NEXT:    negu $2, $1
 ; M32-NEXT:    addiu $1, $1, -1
-; M32-NEXT:    and $2, $1, $4
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $5
+; M32-NEXT:    and $2, $2, $5
+; M32-NEXT:    and $1, $1, $4
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_umax_generic:
 ; M64:       # %bb.0:
@@ -151,10 +150,10 @@ define i32 @test_ctselect_umax_generic(i32 %x, i32 %y) {
 ; M64-NEXT:    sll $2, $5, 0
 ; M64-NEXT:    sltu $3, $2, $1
 ; M64-NEXT:    xori $3, $3, 1
+; M64-NEXT:    negu $4, $3
 ; M64-NEXT:    addiu $3, $3, -1
+; M64-NEXT:    and $2, $4, $2
 ; M64-NEXT:    and $1, $3, $1
-; M64-NEXT:    not $3, $3
-; M64-NEXT:    and $2, $3, $2
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    or $2, $1, $2
   %cmp = icmp ugt i32 %x, %y
@@ -239,18 +238,14 @@ define i32 @test_ctselect_sign_extend(i32 %x) {
 define i32 @test_ctselect_zero_extend(i32 %x) {
 ; M32-LABEL: test_ctselect_zero_extend:
 ; M32:       # %bb.0:
-; M32-NEXT:    sltiu $1, $4, 1
-; M32-NEXT:    addiu $1, $1, -1
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    andi $2, $1, 1
+; M32-NEXT:    sltu $2, $zero, $4
 ;
 ; M64-LABEL: test_ctselect_zero_extend:
 ; M64:       # %bb.0:
 ; M64-NEXT:    sll $1, $4, 0
-; M64-NEXT:    sltiu $1, $1, 1
-; M64-NEXT:    addiu $1, $1, -1
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    andi $2, $1, 1
+; M64-NEXT:    sltu $2, $zero, $1
   %cmp = icmp ne i32 %x, 0
   %result = call i32 @llvm.ct.select.i32(i1 %cmp, i32 1, i32 0)
   ret i32 %result
@@ -289,25 +284,13 @@ define i32 @test_ctselect_constant_folding_false(i32 %a, i32 %b) {
 define i32 @test_ctselect_identical_operands(i1 %cond, i32 %x) {
 ; M32-LABEL: test_ctselect_identical_operands:
 ; M32:       # %bb.0:
-; M32-NEXT:    andi $1, $4, 1
-; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $5
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $5
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    move $2, $5
 ;
 ; M64-LABEL: test_ctselect_identical_operands:
 ; M64:       # %bb.0:
-; M64-NEXT:    sll $1, $4, 0
-; M64-NEXT:    sll $2, $5, 0
-; M64-NEXT:    andi $1, $1, 1
-; M64-NEXT:    negu $1, $1
-; M64-NEXT:    and $3, $1, $2
-; M64-NEXT:    not $1, $1
-; M64-NEXT:    and $1, $1, $2
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    or $2, $3, $1
+; M64-NEXT:    sll $2, $5, 0
   %result = call i32 @llvm.ct.select.i32(i1 %cond, i32 %x, i32 %x)
   ret i32 %result
 }
@@ -318,12 +301,12 @@ define i32 @test_ctselect_inverted_condition(i32 %x, i32 %y, i32 %a, i32 %b) {
 ; M32:       # %bb.0:
 ; M32-NEXT:    xor $1, $4, $5
 ; M32-NEXT:    sltiu $1, $1, 1
+; M32-NEXT:    negu $2, $1
 ; M32-NEXT:    addiu $1, $1, -1
-; M32-NEXT:    and $2, $1, $6
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $7
+; M32-NEXT:    and $2, $2, $7
+; M32-NEXT:    and $1, $1, $6
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_inverted_condition:
 ; M64:       # %bb.0:
@@ -331,14 +314,14 @@ define i32 @test_ctselect_inverted_condition(i32 %x, i32 %y, i32 %a, i32 %b) {
 ; M64-NEXT:    sll $2, $4, 0
 ; M64-NEXT:    sll $3, $7, 0
 ; M64-NEXT:    xor $1, $2, $1
-; M64-NEXT:    sll $2, $6, 0
 ; M64-NEXT:    sltiu $1, $1, 1
+; M64-NEXT:    negu $2, $1
 ; M64-NEXT:    addiu $1, $1, -1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
+; M64-NEXT:    and $2, $2, $3
+; M64-NEXT:    sll $3, $6, 0
 ; M64-NEXT:    and $1, $1, $3
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    or $2, $2, $1
+; M64-NEXT:    or $2, $1, $2
   %cmp = icmp eq i32 %x, %y
   %not_cmp = xor i1 %cmp, true
   %result = call i32 @llvm.ct.select.i32(i1 %not_cmp, i32 %a, i32 %b)
@@ -351,53 +334,53 @@ define i32 @test_ctselect_chain(i1 %c1, i1 %c2, i1 %c3, i32 %a, i32 %b, i32 %c, 
 ; M32:       # %bb.0:
 ; M32-NEXT:    andi $1, $4, 1
 ; M32-NEXT:    lw $3, 16($sp)
+; M32-NEXT:    addiu $2, $1, -1
 ; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $7
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $3
-; M32-NEXT:    lw $3, 20($sp)
-; M32-NEXT:    or $1, $2, $1
-; M32-NEXT:    andi $2, $5, 1
-; M32-NEXT:    negu $2, $2
-; M32-NEXT:    and $1, $2, $1
-; M32-NEXT:    not $2, $2
 ; M32-NEXT:    and $2, $2, $3
-; M32-NEXT:    lw $3, 24($sp)
+; M32-NEXT:    and $1, $1, $7
+; M32-NEXT:    or $1, $1, $2
+; M32-NEXT:    andi $2, $5, 1
+; M32-NEXT:    negu $3, $2
+; M32-NEXT:    addiu $2, $2, -1
+; M32-NEXT:    and $1, $3, $1
+; M32-NEXT:    lw $3, 20($sp)
+; M32-NEXT:    and $2, $2, $3
 ; M32-NEXT:    or $1, $1, $2
 ; M32-NEXT:    andi $2, $6, 1
-; M32-NEXT:    negu $2, $2
-; M32-NEXT:    and $1, $2, $1
-; M32-NEXT:    not $2, $2
+; M32-NEXT:    negu $3, $2
+; M32-NEXT:    addiu $2, $2, -1
+; M32-NEXT:    and $1, $3, $1
+; M32-NEXT:    lw $3, 24($sp)
 ; M32-NEXT:    and $2, $2, $3
 ; M32-NEXT:    jr $ra
 ; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_chain:
 ; M64:       # %bb.0:
-; M64-NEXT:    sll $1, $4, 0
-; M64-NEXT:    sll $2, $7, 0
-; M64-NEXT:    sll $3, $8, 0
-; M64-NEXT:    andi $1, $1, 1
-; M64-NEXT:    negu $1, $1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
-; M64-NEXT:    and $1, $1, $3
-; M64-NEXT:    sll $3, $9, 0
+; M64-NEXT:    sll $2, $4, 0
+; M64-NEXT:    sll $1, $8, 0
+; M64-NEXT:    sll $4, $10, 0
+; M64-NEXT:    andi $2, $2, 1
+; M64-NEXT:    addiu $3, $2, -1
+; M64-NEXT:    negu $2, $2
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    sll $3, $7, 0
+; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    or $1, $2, $1
 ; M64-NEXT:    sll $2, $5, 0
 ; M64-NEXT:    andi $2, $2, 1
-; M64-NEXT:    negu $2, $2
-; M64-NEXT:    and $1, $2, $1
-; M64-NEXT:    not $2, $2
+; M64-NEXT:    negu $3, $2
+; M64-NEXT:    addiu $2, $2, -1
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    sll $3, $9, 0
 ; M64-NEXT:    and $2, $2, $3
-; M64-NEXT:    sll $3, $6, 0
 ; M64-NEXT:    or $1, $1, $2
-; M64-NEXT:    andi $2, $3, 1
-; M64-NEXT:    sll $3, $10, 0
-; M64-NEXT:    negu $2, $2
-; M64-NEXT:    and $1, $2, $1
-; M64-NEXT:    not $2, $2
-; M64-NEXT:    and $2, $2, $3
+; M64-NEXT:    sll $2, $6, 0
+; M64-NEXT:    andi $2, $2, 1
+; M64-NEXT:    negu $3, $2
+; M64-NEXT:    addiu $2, $2, -1
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    and $2, $2, $4
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    or $2, $1, $2
   %sel1 = call i32 @llvm.ct.select.i32(i1 %c1, i32 %a, i32 %b)

--- a/llvm/test/CodeGen/Mips/ctselect-fallback.ll
+++ b/llvm/test/CodeGen/Mips/ctselect-fallback.ll
@@ -61,23 +61,23 @@ define i32 @test_ctselect_i32(i1 %cond, i32 %a, i32 %b) {
 ; M32-LABEL: test_ctselect_i32:
 ; M32:       # %bb.0:
 ; M32-NEXT:    andi $1, $4, 1
+; M32-NEXT:    addiu $2, $1, -1
 ; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $5
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $6
+; M32-NEXT:    and $2, $2, $6
+; M32-NEXT:    and $1, $1, $5
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_i32:
 ; M64:       # %bb.0:
-; M64-NEXT:    sll $1, $4, 0
-; M64-NEXT:    sll $2, $5, 0
-; M64-NEXT:    sll $3, $6, 0
-; M64-NEXT:    andi $1, $1, 1
-; M64-NEXT:    negu $1, $1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
-; M64-NEXT:    and $1, $1, $3
+; M64-NEXT:    sll $2, $4, 0
+; M64-NEXT:    sll $1, $6, 0
+; M64-NEXT:    andi $2, $2, 1
+; M64-NEXT:    addiu $3, $2, -1
+; M64-NEXT:    negu $2, $2
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    sll $3, $5, 0
+; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    or $2, $2, $1
   %result = call i32 @llvm.ct.select.i32(i1 %cond, i32 %a, i32 %b)
@@ -103,13 +103,12 @@ define i64 @test_ctselect_i64(i1 %cond, i64 %a, i64 %b) {
 ; M64-LABEL: test_ctselect_i64:
 ; M64:       # %bb.0:
 ; M64-NEXT:    andi $1, $4, 1
-; M64-NEXT:    daddiu $3, $zero, -1
+; M64-NEXT:    daddiu $2, $1, -1
 ; M64-NEXT:    dnegu $1, $1
-; M64-NEXT:    and $2, $1, $5
-; M64-NEXT:    xor $1, $1, $3
-; M64-NEXT:    and $1, $1, $6
+; M64-NEXT:    and $2, $2, $6
+; M64-NEXT:    and $1, $1, $5
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    or $2, $2, $1
+; M64-NEXT:    or $2, $1, $2
   %result = call i64 @llvm.ct.select.i64(i1 %cond, i64 %a, i64 %b)
   ret i64 %result
 }
@@ -118,23 +117,22 @@ define ptr @test_ctselect_ptr(i1 %cond, ptr %a, ptr %b) {
 ; M32-LABEL: test_ctselect_ptr:
 ; M32:       # %bb.0:
 ; M32-NEXT:    andi $1, $4, 1
+; M32-NEXT:    addiu $2, $1, -1
 ; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $5
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $6
+; M32-NEXT:    and $2, $2, $6
+; M32-NEXT:    and $1, $1, $5
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_ptr:
 ; M64:       # %bb.0:
 ; M64-NEXT:    andi $1, $4, 1
-; M64-NEXT:    daddiu $3, $zero, -1
+; M64-NEXT:    daddiu $2, $1, -1
 ; M64-NEXT:    dnegu $1, $1
-; M64-NEXT:    and $2, $1, $5
-; M64-NEXT:    xor $1, $1, $3
-; M64-NEXT:    and $1, $1, $6
+; M64-NEXT:    and $2, $2, $6
+; M64-NEXT:    and $1, $1, $5
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    or $2, $2, $1
+; M64-NEXT:    or $2, $1, $2
   %result = call ptr @llvm.ct.select.p0(i1 %cond, ptr %a, ptr %b)
   ret ptr %result
 }
@@ -174,12 +172,12 @@ define i32 @test_ctselect_icmp_eq(i32 %x, i32 %y, i32 %a, i32 %b) {
 ; M32:       # %bb.0:
 ; M32-NEXT:    xor $1, $4, $5
 ; M32-NEXT:    sltu $1, $zero, $1
+; M32-NEXT:    negu $2, $1
 ; M32-NEXT:    addiu $1, $1, -1
-; M32-NEXT:    and $2, $1, $6
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $7
+; M32-NEXT:    and $2, $2, $7
+; M32-NEXT:    and $1, $1, $6
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_icmp_eq:
 ; M64:       # %bb.0:
@@ -187,14 +185,14 @@ define i32 @test_ctselect_icmp_eq(i32 %x, i32 %y, i32 %a, i32 %b) {
 ; M64-NEXT:    sll $2, $4, 0
 ; M64-NEXT:    sll $3, $7, 0
 ; M64-NEXT:    xor $1, $2, $1
-; M64-NEXT:    sll $2, $6, 0
 ; M64-NEXT:    sltu $1, $zero, $1
+; M64-NEXT:    negu $2, $1
 ; M64-NEXT:    addiu $1, $1, -1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
+; M64-NEXT:    and $2, $2, $3
+; M64-NEXT:    sll $3, $6, 0
 ; M64-NEXT:    and $1, $1, $3
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    or $2, $2, $1
+; M64-NEXT:    or $2, $1, $2
   %cond = icmp eq i32 %x, %y
   %result = call i32 @llvm.ct.select.i32(i1 %cond, i32 %a, i32 %b)
   ret i32 %result
@@ -205,12 +203,12 @@ define i32 @test_ctselect_icmp_ne(i32 %x, i32 %y, i32 %a, i32 %b) {
 ; M32:       # %bb.0:
 ; M32-NEXT:    xor $1, $4, $5
 ; M32-NEXT:    sltiu $1, $1, 1
+; M32-NEXT:    negu $2, $1
 ; M32-NEXT:    addiu $1, $1, -1
-; M32-NEXT:    and $2, $1, $6
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $7
+; M32-NEXT:    and $2, $2, $7
+; M32-NEXT:    and $1, $1, $6
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_icmp_ne:
 ; M64:       # %bb.0:
@@ -218,14 +216,14 @@ define i32 @test_ctselect_icmp_ne(i32 %x, i32 %y, i32 %a, i32 %b) {
 ; M64-NEXT:    sll $2, $4, 0
 ; M64-NEXT:    sll $3, $7, 0
 ; M64-NEXT:    xor $1, $2, $1
-; M64-NEXT:    sll $2, $6, 0
 ; M64-NEXT:    sltiu $1, $1, 1
+; M64-NEXT:    negu $2, $1
 ; M64-NEXT:    addiu $1, $1, -1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
+; M64-NEXT:    and $2, $2, $3
+; M64-NEXT:    sll $3, $6, 0
 ; M64-NEXT:    and $1, $1, $3
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    or $2, $2, $1
+; M64-NEXT:    or $2, $1, $2
   %cond = icmp ne i32 %x, %y
   %result = call i32 @llvm.ct.select.i32(i1 %cond, i32 %a, i32 %b)
   ret i32 %result
@@ -236,12 +234,12 @@ define i32 @test_ctselect_icmp_slt(i32 %x, i32 %y, i32 %a, i32 %b) {
 ; M32:       # %bb.0:
 ; M32-NEXT:    slt $1, $4, $5
 ; M32-NEXT:    xori $1, $1, 1
+; M32-NEXT:    negu $2, $1
 ; M32-NEXT:    addiu $1, $1, -1
-; M32-NEXT:    and $2, $1, $6
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $7
+; M32-NEXT:    and $2, $2, $7
+; M32-NEXT:    and $1, $1, $6
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_icmp_slt:
 ; M64:       # %bb.0:
@@ -249,14 +247,14 @@ define i32 @test_ctselect_icmp_slt(i32 %x, i32 %y, i32 %a, i32 %b) {
 ; M64-NEXT:    sll $2, $4, 0
 ; M64-NEXT:    sll $3, $7, 0
 ; M64-NEXT:    slt $1, $2, $1
-; M64-NEXT:    sll $2, $6, 0
 ; M64-NEXT:    xori $1, $1, 1
+; M64-NEXT:    negu $2, $1
 ; M64-NEXT:    addiu $1, $1, -1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
+; M64-NEXT:    and $2, $2, $3
+; M64-NEXT:    sll $3, $6, 0
 ; M64-NEXT:    and $1, $1, $3
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    or $2, $2, $1
+; M64-NEXT:    or $2, $1, $2
   %cond = icmp slt i32 %x, %y
   %result = call i32 @llvm.ct.select.i32(i1 %cond, i32 %a, i32 %b)
   ret i32 %result
@@ -267,12 +265,12 @@ define i32 @test_ctselect_icmp_ult(i32 %x, i32 %y, i32 %a, i32 %b) {
 ; M32:       # %bb.0:
 ; M32-NEXT:    sltu $1, $4, $5
 ; M32-NEXT:    xori $1, $1, 1
+; M32-NEXT:    negu $2, $1
 ; M32-NEXT:    addiu $1, $1, -1
-; M32-NEXT:    and $2, $1, $6
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $7
+; M32-NEXT:    and $2, $2, $7
+; M32-NEXT:    and $1, $1, $6
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_icmp_ult:
 ; M64:       # %bb.0:
@@ -280,14 +278,14 @@ define i32 @test_ctselect_icmp_ult(i32 %x, i32 %y, i32 %a, i32 %b) {
 ; M64-NEXT:    sll $2, $4, 0
 ; M64-NEXT:    sll $3, $7, 0
 ; M64-NEXT:    sltu $1, $2, $1
-; M64-NEXT:    sll $2, $6, 0
 ; M64-NEXT:    xori $1, $1, 1
+; M64-NEXT:    negu $2, $1
 ; M64-NEXT:    addiu $1, $1, -1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
+; M64-NEXT:    and $2, $2, $3
+; M64-NEXT:    sll $3, $6, 0
 ; M64-NEXT:    and $1, $1, $3
 ; M64-NEXT:    jr $ra
-; M64-NEXT:    or $2, $2, $1
+; M64-NEXT:    or $2, $1, $2
   %cond = icmp ult i32 %x, %y
   %result = call i32 @llvm.ct.select.i32(i1 %cond, i32 %a, i32 %b)
   ret i32 %result
@@ -297,26 +295,26 @@ define i32 @test_ctselect_icmp_ult(i32 %x, i32 %y, i32 %a, i32 %b) {
 define i32 @test_ctselect_load(i1 %cond, ptr %p1, ptr %p2) {
 ; M32-LABEL: test_ctselect_load:
 ; M32:       # %bb.0:
-; M32-NEXT:    andi $1, $4, 1
-; M32-NEXT:    lw $2, 0($5)
-; M32-NEXT:    lw $3, 0($6)
-; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $2
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $3
+; M32-NEXT:    andi $2, $4, 1
+; M32-NEXT:    lw $1, 0($6)
+; M32-NEXT:    addiu $3, $2, -1
+; M32-NEXT:    negu $2, $2
+; M32-NEXT:    and $1, $3, $1
+; M32-NEXT:    lw $3, 0($5)
+; M32-NEXT:    and $2, $2, $3
 ; M32-NEXT:    jr $ra
 ; M32-NEXT:    or $2, $2, $1
 ;
 ; M64-LABEL: test_ctselect_load:
 ; M64:       # %bb.0:
-; M64-NEXT:    sll $1, $4, 0
-; M64-NEXT:    lw $2, 0($5)
-; M64-NEXT:    lw $3, 0($6)
-; M64-NEXT:    andi $1, $1, 1
-; M64-NEXT:    negu $1, $1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
-; M64-NEXT:    and $1, $1, $3
+; M64-NEXT:    sll $2, $4, 0
+; M64-NEXT:    lw $1, 0($6)
+; M64-NEXT:    andi $2, $2, 1
+; M64-NEXT:    addiu $3, $2, -1
+; M64-NEXT:    negu $2, $2
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    lw $3, 0($5)
+; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    or $2, $2, $1
   %a = load i32, ptr %p1
@@ -330,37 +328,37 @@ define i32 @test_ctselect_nested(i1 %cond1, i1 %cond2, i32 %a, i32 %b, i32 %c) {
 ; M32-LABEL: test_ctselect_nested:
 ; M32:       # %bb.0:
 ; M32-NEXT:    andi $1, $5, 1
-; M32-NEXT:    lw $3, 16($sp)
+; M32-NEXT:    addiu $2, $1, -1
 ; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $6
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $7
-; M32-NEXT:    or $1, $2, $1
+; M32-NEXT:    and $2, $2, $7
+; M32-NEXT:    and $1, $1, $6
+; M32-NEXT:    or $1, $1, $2
 ; M32-NEXT:    andi $2, $4, 1
-; M32-NEXT:    negu $2, $2
-; M32-NEXT:    and $1, $2, $1
-; M32-NEXT:    not $2, $2
+; M32-NEXT:    negu $3, $2
+; M32-NEXT:    addiu $2, $2, -1
+; M32-NEXT:    and $1, $3, $1
+; M32-NEXT:    lw $3, 16($sp)
 ; M32-NEXT:    and $2, $2, $3
 ; M32-NEXT:    jr $ra
 ; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_ctselect_nested:
 ; M64:       # %bb.0:
-; M64-NEXT:    sll $1, $5, 0
-; M64-NEXT:    sll $2, $6, 0
-; M64-NEXT:    sll $3, $7, 0
-; M64-NEXT:    andi $1, $1, 1
-; M64-NEXT:    negu $1, $1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
-; M64-NEXT:    and $1, $1, $3
-; M64-NEXT:    sll $3, $8, 0
+; M64-NEXT:    sll $2, $5, 0
+; M64-NEXT:    sll $1, $7, 0
+; M64-NEXT:    andi $2, $2, 1
+; M64-NEXT:    addiu $3, $2, -1
+; M64-NEXT:    negu $2, $2
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    sll $3, $6, 0
+; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    or $1, $2, $1
 ; M64-NEXT:    sll $2, $4, 0
 ; M64-NEXT:    andi $2, $2, 1
-; M64-NEXT:    negu $2, $2
-; M64-NEXT:    and $1, $2, $1
-; M64-NEXT:    not $2, $2
+; M64-NEXT:    negu $3, $2
+; M64-NEXT:    addiu $2, $2, -1
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    sll $3, $8, 0
 ; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    or $2, $1, $2
@@ -374,24 +372,24 @@ define float @test_ctselect_f32(i1 %cond, float %a, float %b) {
 ; M32-LABEL: test_ctselect_f32:
 ; M32:       # %bb.0:
 ; M32-NEXT:    andi $1, $4, 1
+; M32-NEXT:    addiu $2, $1, -1
 ; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $5
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $6
-; M32-NEXT:    or $1, $2, $1
+; M32-NEXT:    and $2, $2, $6
+; M32-NEXT:    and $1, $1, $5
+; M32-NEXT:    or $1, $1, $2
 ; M32-NEXT:    jr $ra
 ; M32-NEXT:    mtc1 $1, $f0
 ;
 ; M64-LABEL: test_ctselect_f32:
 ; M64:       # %bb.0:
-; M64-NEXT:    sll $1, $4, 0
-; M64-NEXT:    mfc1 $2, $f13
-; M64-NEXT:    mfc1 $3, $f14
-; M64-NEXT:    andi $1, $1, 1
-; M64-NEXT:    negu $1, $1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
-; M64-NEXT:    and $1, $1, $3
+; M64-NEXT:    sll $2, $4, 0
+; M64-NEXT:    mfc1 $1, $f14
+; M64-NEXT:    andi $2, $2, 1
+; M64-NEXT:    addiu $3, $2, -1
+; M64-NEXT:    negu $2, $2
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    mfc1 $3, $f13
+; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    or $1, $2, $1
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    mtc1 $1, $f0
@@ -429,14 +427,13 @@ define double @test_ctselect_f64(i1 %cond, double %a, double %b) {
 ;
 ; M64-LABEL: test_ctselect_f64:
 ; M64:       # %bb.0:
-; M64-NEXT:    andi $1, $4, 1
-; M64-NEXT:    dmfc1 $2, $f13
-; M64-NEXT:    daddiu $3, $zero, -1
-; M64-NEXT:    dnegu $1, $1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    xor $1, $1, $3
-; M64-NEXT:    dmfc1 $3, $f14
-; M64-NEXT:    and $1, $1, $3
+; M64-NEXT:    andi $2, $4, 1
+; M64-NEXT:    dmfc1 $1, $f14
+; M64-NEXT:    daddiu $3, $2, -1
+; M64-NEXT:    dnegu $2, $2
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    dmfc1 $3, $f13
+; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    or $1, $2, $1
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    dmtc1 $1, $f0
@@ -450,16 +447,16 @@ define float @test_ctselect_f32_chain(i1 %cond1, i1 %cond2, float %a, float %b, 
 ; M32-LABEL: test_ctselect_f32_chain:
 ; M32:       # %bb.0:
 ; M32-NEXT:    andi $1, $4, 1
-; M32-NEXT:    lw $3, 16($sp)
+; M32-NEXT:    addiu $2, $1, -1
 ; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $6
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $7
-; M32-NEXT:    or $1, $2, $1
+; M32-NEXT:    and $2, $2, $7
+; M32-NEXT:    and $1, $1, $6
+; M32-NEXT:    or $1, $1, $2
 ; M32-NEXT:    andi $2, $5, 1
-; M32-NEXT:    negu $2, $2
-; M32-NEXT:    and $1, $2, $1
-; M32-NEXT:    not $2, $2
+; M32-NEXT:    negu $3, $2
+; M32-NEXT:    addiu $2, $2, -1
+; M32-NEXT:    and $1, $3, $1
+; M32-NEXT:    lw $3, 16($sp)
 ; M32-NEXT:    and $2, $2, $3
 ; M32-NEXT:    or $1, $1, $2
 ; M32-NEXT:    jr $ra
@@ -467,21 +464,21 @@ define float @test_ctselect_f32_chain(i1 %cond1, i1 %cond2, float %a, float %b, 
 ;
 ; M64-LABEL: test_ctselect_f32_chain:
 ; M64:       # %bb.0:
-; M64-NEXT:    sll $1, $4, 0
-; M64-NEXT:    mfc1 $2, $f14
-; M64-NEXT:    mfc1 $3, $f15
-; M64-NEXT:    andi $1, $1, 1
-; M64-NEXT:    negu $1, $1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
-; M64-NEXT:    and $1, $1, $3
-; M64-NEXT:    mfc1 $3, $f16
+; M64-NEXT:    sll $2, $4, 0
+; M64-NEXT:    mfc1 $1, $f15
+; M64-NEXT:    andi $2, $2, 1
+; M64-NEXT:    addiu $3, $2, -1
+; M64-NEXT:    negu $2, $2
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    mfc1 $3, $f14
+; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    or $1, $2, $1
 ; M64-NEXT:    sll $2, $5, 0
 ; M64-NEXT:    andi $2, $2, 1
-; M64-NEXT:    negu $2, $2
-; M64-NEXT:    and $1, $2, $1
-; M64-NEXT:    not $2, $2
+; M64-NEXT:    negu $3, $2
+; M64-NEXT:    addiu $2, $2, -1
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    mfc1 $3, $f16
 ; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    or $1, $1, $2
 ; M64-NEXT:    jr $ra
@@ -495,27 +492,27 @@ define float @test_ctselect_f32_chain(i1 %cond1, i1 %cond2, float %a, float %b, 
 define float @test_ctselect_f32_load(i1 %cond, ptr %p1, ptr %p2) {
 ; M32-LABEL: test_ctselect_f32_load:
 ; M32:       # %bb.0:
-; M32-NEXT:    andi $1, $4, 1
-; M32-NEXT:    lw $2, 0($5)
-; M32-NEXT:    lw $3, 0($6)
-; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $2
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $3
+; M32-NEXT:    andi $2, $4, 1
+; M32-NEXT:    lw $1, 0($6)
+; M32-NEXT:    addiu $3, $2, -1
+; M32-NEXT:    negu $2, $2
+; M32-NEXT:    and $1, $3, $1
+; M32-NEXT:    lw $3, 0($5)
+; M32-NEXT:    and $2, $2, $3
 ; M32-NEXT:    or $1, $2, $1
 ; M32-NEXT:    jr $ra
 ; M32-NEXT:    mtc1 $1, $f0
 ;
 ; M64-LABEL: test_ctselect_f32_load:
 ; M64:       # %bb.0:
-; M64-NEXT:    sll $1, $4, 0
-; M64-NEXT:    lw $2, 0($5)
-; M64-NEXT:    lw $3, 0($6)
-; M64-NEXT:    andi $1, $1, 1
-; M64-NEXT:    negu $1, $1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
-; M64-NEXT:    and $1, $1, $3
+; M64-NEXT:    sll $2, $4, 0
+; M64-NEXT:    lw $1, 0($6)
+; M64-NEXT:    andi $2, $2, 1
+; M64-NEXT:    addiu $3, $2, -1
+; M64-NEXT:    negu $2, $2
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    lw $3, 0($5)
+; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    or $1, $2, $1
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    mtc1 $1, $f0
@@ -552,14 +549,13 @@ define double @test_ctselect_f64_load(i1 %cond, ptr %p1, ptr %p2) {
 ;
 ; M64-LABEL: test_ctselect_f64_load:
 ; M64:       # %bb.0:
-; M64-NEXT:    andi $1, $4, 1
-; M64-NEXT:    ld $2, 0($5)
-; M64-NEXT:    daddiu $3, $zero, -1
-; M64-NEXT:    dnegu $1, $1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    xor $1, $1, $3
-; M64-NEXT:    ld $3, 0($6)
-; M64-NEXT:    and $1, $1, $3
+; M64-NEXT:    andi $2, $4, 1
+; M64-NEXT:    ld $1, 0($6)
+; M64-NEXT:    daddiu $3, $2, -1
+; M64-NEXT:    dnegu $2, $2
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    ld $3, 0($5)
+; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    or $1, $2, $1
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    dmtc1 $1, $f0
@@ -575,15 +571,15 @@ define float @test_ctselect_f32_arithmetic(i1 %cond, float %x, float %y) {
 ; M32:       # %bb.0:
 ; M32-NEXT:    mtc1 $6, $f0
 ; M32-NEXT:    mtc1 $5, $f1
-; M32-NEXT:    andi $2, $4, 1
-; M32-NEXT:    negu $2, $2
-; M32-NEXT:    sub.s $f2, $f1, $f0
-; M32-NEXT:    add.s $f0, $f1, $f0
-; M32-NEXT:    not $3, $2
-; M32-NEXT:    mfc1 $1, $f2
-; M32-NEXT:    and $1, $3, $1
-; M32-NEXT:    mfc1 $3, $f0
+; M32-NEXT:    andi $1, $4, 1
+; M32-NEXT:    negu $2, $1
+; M32-NEXT:    addiu $1, $1, -1
+; M32-NEXT:    add.s $f2, $f1, $f0
+; M32-NEXT:    sub.s $f0, $f1, $f0
+; M32-NEXT:    mfc1 $3, $f2
 ; M32-NEXT:    and $2, $2, $3
+; M32-NEXT:    mfc1 $3, $f0
+; M32-NEXT:    and $1, $1, $3
 ; M32-NEXT:    or $1, $2, $1
 ; M32-NEXT:    jr $ra
 ; M32-NEXT:    mtc1 $1, $f0
@@ -593,11 +589,11 @@ define float @test_ctselect_f32_arithmetic(i1 %cond, float %x, float %y) {
 ; M64-NEXT:    add.s $f0, $f13, $f14
 ; M64-NEXT:    sll $1, $4, 0
 ; M64-NEXT:    andi $1, $1, 1
-; M64-NEXT:    negu $1, $1
-; M64-NEXT:    mfc1 $2, $f0
+; M64-NEXT:    negu $2, $1
+; M64-NEXT:    addiu $1, $1, -1
+; M64-NEXT:    mfc1 $3, $f0
 ; M64-NEXT:    sub.s $f0, $f13, $f14
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
+; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    mfc1 $3, $f0
 ; M64-NEXT:    and $1, $1, $3
 ; M64-NEXT:    or $1, $2, $1

--- a/llvm/test/CodeGen/Mips/ctselect-side-effects.ll
+++ b/llvm/test/CodeGen/Mips/ctselect-side-effects.ll
@@ -39,23 +39,23 @@ define i32 @test_protected_no_branch(i1 %cond, i32 %a, i32 %b) {
 ; M32-LABEL: test_protected_no_branch:
 ; M32:       # %bb.0:
 ; M32-NEXT:    andi $1, $4, 1
+; M32-NEXT:    addiu $2, $1, -1
 ; M32-NEXT:    negu $1, $1
-; M32-NEXT:    and $2, $1, $5
-; M32-NEXT:    not $1, $1
-; M32-NEXT:    and $1, $1, $6
+; M32-NEXT:    and $2, $2, $6
+; M32-NEXT:    and $1, $1, $5
 ; M32-NEXT:    jr $ra
-; M32-NEXT:    or $2, $2, $1
+; M32-NEXT:    or $2, $1, $2
 ;
 ; M64-LABEL: test_protected_no_branch:
 ; M64:       # %bb.0:
-; M64-NEXT:    sll $1, $4, 0
-; M64-NEXT:    sll $2, $5, 0
-; M64-NEXT:    sll $3, $6, 0
-; M64-NEXT:    andi $1, $1, 1
-; M64-NEXT:    negu $1, $1
-; M64-NEXT:    and $2, $1, $2
-; M64-NEXT:    not $1, $1
-; M64-NEXT:    and $1, $1, $3
+; M64-NEXT:    sll $2, $4, 0
+; M64-NEXT:    sll $1, $6, 0
+; M64-NEXT:    andi $2, $2, 1
+; M64-NEXT:    addiu $3, $2, -1
+; M64-NEXT:    negu $2, $2
+; M64-NEXT:    and $1, $3, $1
+; M64-NEXT:    sll $3, $5, 0
+; M64-NEXT:    and $2, $2, $3
 ; M64-NEXT:    jr $ra
 ; M64-NEXT:    or $2, $2, $1
   %result = call i32 @llvm.ct.select.i32(i1 %cond, i32 %a, i32 %b)


### PR DESCRIPTION
Simply just generated the proper asm for Mips, that was affected by DAG Chaining. I forgot to add it previously, which led to this output when running `ninja check-all` (disregard the `tools/llvm-objcopy/ELF/strip-preserve-atime.test`):
```
********************
Failed Tests (5):
  LLVM :: CodeGen/Mips/ctselect-fallback-edge-cases.ll
  LLVM :: CodeGen/Mips/ctselect-fallback-patterns.ll
  LLVM :: CodeGen/Mips/ctselect-fallback.ll
  LLVM :: CodeGen/Mips/ctselect-side-effects.ll
  LLVM :: tools/llvm-objcopy/ELF/strip-preserve-atime.test


Testing Time: 617.97s

Total Discovered Tests: 110388
  Skipped          :    55 (0.05%)
  Unsupported      : 15421 (13.97%)
  Passed           : 94733 (85.82%)
  Expectedly Failed:   174 (0.16%)
  Failed           :     5 (0.00%)
```