### PR TITLE
[CT] create instruction bundle during post RA expansion

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -6846,6 +6846,10 @@ void SelectionDAGBuilder::visitIntrinsicCall(const CallInst &I,
           "llvm.ct.select: predicates with vector types not supported yet");
     }
 
+    // Set function attribute to indicate ct.select usage
+    Function &F = DAG.getMachineFunction().getFunction();
+    F.addFnAttr("ct-select");
+
     // Handle scalar types
     if (TLI.isSelectSupported(
             TargetLoweringBase::SelectSupportKind::CtSelect) &&

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -894,9 +894,7 @@ void AArch64PassConfig::addPostBBSections() {
 void AArch64PassConfig::addPreEmitPass2() {
   // SVE bundles move prefixes with destructive operations. BLR_RVMARKER pseudo
   // instructions are lowered to bundles as well.
-  addPass(createUnpackMachineBundles([](const MachineFunction &MF) {
-    return MF.getFunction().hasFnAttribute("ct-select");
-  }));
+  addPass(createUnpackMachineBundles(nullptr));
 }
 
 bool AArch64PassConfig::addRegAssignAndRewriteOptimized() {

--- a/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
+++ b/llvm/lib/Target/AArch64/AArch64TargetMachine.cpp
@@ -894,7 +894,9 @@ void AArch64PassConfig::addPostBBSections() {
 void AArch64PassConfig::addPreEmitPass2() {
   // SVE bundles move prefixes with destructive operations. BLR_RVMARKER pseudo
   // instructions are lowered to bundles as well.
-  addPass(createUnpackMachineBundles(nullptr));
+  addPass(createUnpackMachineBundles([](const MachineFunction &MF) {
+    return MF.getFunction().hasFnAttribute("ct-select");
+  }));
 }
 
 bool AArch64PassConfig::addRegAssignAndRewriteOptimized() {

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -1737,7 +1737,8 @@ bool ARMBaseInstrInfo::expandCtSelectVector(MachineInstr &MI) const {
   // When cond = 0: mask = 0x00000000.
   // When cond = 1: mask = 0xFFFFFFFF.
 
-  BuildMI(*MBB, MI, DL, get(RsbOp), MaskReg)
+  MachineInstr *FirstNewMI =
+    BuildMI(*MBB, MI, DL, get(RsbOp), MaskReg)
     .addReg(CondReg)
     .addImm(0)
     .add(predOps(ARMCC::AL))
@@ -1765,11 +1766,17 @@ bool ARMBaseInstrInfo::expandCtSelectVector(MachineInstr &MI) const {
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
 
   // 4. result = A | B
-  BuildMI(*MBB, MI, DL, get(OrrOp), DestReg)
+  auto LastNewMI = BuildMI(*MBB, MI, DL, get(OrrOp), DestReg)
     .addReg(DestReg)
     .addReg(VectorMaskReg)
     .add(predOps(ARMCC::AL))
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
+
+  auto BundleStart = FirstNewMI->getIterator();
+  auto BundleEnd = LastNewMI->getIterator();
+
+  // Add instruction bundling
+  finalizeBundle(*MBB, BundleStart, std::next(BundleEnd));
   
   MI.eraseFromParent();
   return true;
@@ -1797,7 +1804,8 @@ bool ARMBaseInstrInfo::expandCtSelectThumb(MachineInstr &MI) const {
   unsigned ShiftAmount = RegSize - 1;
 
   // Option 1: Shift-based mask (preferred - no flag modification)
-  BuildMI(*MBB, MI, DL, get(ARM::tMOVr), MaskReg)
+  MachineInstr *FirstNewMI =
+    BuildMI(*MBB, MI, DL, get(ARM::tMOVr), MaskReg)
     .addReg(CondReg)
     .add(predOps(ARMCC::AL))
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
@@ -1835,11 +1843,15 @@ bool ARMBaseInstrInfo::expandCtSelectThumb(MachineInstr &MI) const {
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
 
   // 4. result = src2 ^ masked_xor
-  BuildMI(*MBB, MI, DL, get(ARM::tEOR), DestReg)
+  auto LastMI = BuildMI(*MBB, MI, DL, get(ARM::tEOR), DestReg)
     .addReg(DestReg)
     .addReg(Src2Reg)
     .add(predOps(ARMCC::AL))
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
+
+      // Add instruction bundling
+  auto BundleStart = FirstNewMI->getIterator();
+  finalizeBundle(*MBB, BundleStart, std::next(LastMI->getIterator()));
 
   MI.eraseFromParent();
   return true;
@@ -1870,6 +1882,7 @@ bool ARMBaseInstrInfo::expandCtSelect(MachineInstr &MI) const {
 
   unsigned Opcode = MI.getOpcode();
   bool IsFloat = Opcode == ARM::CTSELECTf32 || Opcode == ARM::CTSELECTf16 || Opcode == ARM::CTSELECTbf16;
+  MachineInstr *FirstNewMI = nullptr;
   if (IsFloat) {
     // Each float pseudo has: (outs $dst, $tmp_mask, $scratch1, $scratch2), (ins $src1, $src2, $cond))
     // We use two scratch registers in tablegen for bitwise ops on float types,.
@@ -1883,11 +1896,11 @@ bool ARMBaseInstrInfo::expandCtSelect(MachineInstr &MI) const {
      // cond from __builtin_ct_select(cond, a, b)
      CondReg = MI.getOperand(6).getReg();
 
-     // Move fp src1 to GPR scratch1 so we can do our bitwise ops
-     BuildMI(*MBB, MI, DL, get(ARM::VMOVRS), GPRScratch1)
-      .addReg(Src1Reg)
-      .add(predOps(ARMCC::AL))
-      .setMIFlag(MachineInstr::MIFlag::NoMerge);
+    // Move fp src1 to GPR scratch1 so we can do our bitwise ops
+    FirstNewMI = BuildMI(*MBB, MI, DL, get(ARM::VMOVRS), GPRScratch1)
+        .addReg(Src1Reg)
+        .add(predOps(ARMCC::AL))
+        .setMIFlag(MachineInstr::MIFlag::NoMerge);
       
     // Move src2 to scratch2
     BuildMI(*MBB, MI, DL, get(ARM::VMOVRS), GPRScratch2)
@@ -1911,13 +1924,17 @@ bool ARMBaseInstrInfo::expandCtSelect(MachineInstr &MI) const {
   // 1. mask = 0 - cond
   // When cond = 0: mask = 0x00000000.
   // When cond = 1: mask = 0xFFFFFFFF.
-  BuildMI(*MBB, MI, DL, get(RsbOp), MaskReg)
-    .addReg(CondReg)
-    .addImm(0)
-    .add(predOps(ARMCC::AL))
-    .add(condCodeOp())
-    .setMIFlag(MachineInstr::MIFlag::NoMerge);
-  
+  auto TmpNewMI = BuildMI(*MBB, MI, DL, get(RsbOp), MaskReg)
+      .addReg(CondReg)
+      .addImm(0)
+      .add(predOps(ARMCC::AL))
+      .add(condCodeOp())
+      .setMIFlag(MachineInstr::MIFlag::NoMerge);
+
+  // We use the first instruction in the bundle as the first instruction.
+  if (!FirstNewMI)
+    FirstNewMI = TmpNewMI;
+
   // 2. A = src1 & mask
   BuildMI(*MBB, MI, DL, get(AndOp), DestReg)
     .addReg(Src1Reg)
@@ -1935,7 +1952,7 @@ bool ARMBaseInstrInfo::expandCtSelect(MachineInstr &MI) const {
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
 
   // 4. result = A | B
-  BuildMI(*MBB, MI, DL, get(OrrOp), DestReg)
+  auto LastNewMI = BuildMI(*MBB, MI, DL, get(OrrOp), DestReg)
     .addReg(DestReg)
     .addReg(MaskReg)
     .add(predOps(ARMCC::AL))
@@ -1944,11 +1961,17 @@ bool ARMBaseInstrInfo::expandCtSelect(MachineInstr &MI) const {
 
   if (IsFloat) {
     // Return our result from GPR to the correct register type.
-    BuildMI(*MBB, MI, DL, get(ARM::VMOVSR), DestRegSavedRef)
+    LastNewMI =BuildMI(*MBB, MI, DL, get(ARM::VMOVSR), DestRegSavedRef)
       .addReg(DestReg)
       .add(predOps(ARMCC::AL))
       .setMIFlag(MachineInstr::MIFlag::NoMerge);
   }
+
+  auto BundleStart = FirstNewMI->getIterator();
+  auto BundleEnd = LastNewMI->getIterator();
+
+  // Add instruction bundling
+  finalizeBundle(*MBB, BundleStart, std::next(BundleEnd));
   
   MI.eraseFromParent();
   return true;

--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -1849,7 +1849,7 @@ bool ARMBaseInstrInfo::expandCtSelectThumb(MachineInstr &MI) const {
     .add(predOps(ARMCC::AL))
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
 
-      // Add instruction bundling
+  // Add instruction bundling
   auto BundleStart = FirstNewMI->getIterator();
   finalizeBundle(*MBB, BundleStart, std::next(LastMI->getIterator()));
 

--- a/llvm/lib/Target/ARM/ARMTargetMachine.cpp
+++ b/llvm/lib/Target/ARM/ARMTargetMachine.cpp
@@ -589,7 +589,8 @@ void ARMPassConfig::addPreEmitPass() {
 
   // Constant island pass work on unbundled instructions.
   addPass(createUnpackMachineBundles([](const MachineFunction &MF) {
-    return MF.getSubtarget<ARMSubtarget>().isThumb2();
+    return MF.getSubtarget<ARMSubtarget>().isThumb2() ||
+    MF.getFunction().hasFnAttribute("ct-select");
   }));
 
   // Don't optimize barriers or block placement at -O0.

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -667,61 +667,73 @@ bool X86InstrInfo::expandCtSelectVector(MachineInstr &MI) const {
   Register TrueVal = MI.getOperand(4).getReg();  // false_value
   X86::CondCode CC = X86::CondCode(MI.getOperand(5).getImm()); // condition
 
+  MachineInstr *FirstInstr = nullptr;
+  MachineInstr *LastInstr = nullptr;
+  auto recordInstr = [&](MachineInstrBuilder MIB) {
+    MachineInstr *NewMI = MIB.getInstr();
+    LastInstr = NewMI;
+    if (!FirstInstr)
+      FirstInstr = NewMI;
+  };
+
   // Create scalar mask in tempGPR and broadcast to vector mask
-  auto FirstNewMI = BuildMI(*MBB, MI, DL, get(X86::MOV32ri), TmpGPR)
-      .addImm(0)
-      .setMIFlags(MachineInstr::MIFlag::NoMerge);
+  recordInstr(BuildMI(*MBB, MI, DL, get(X86::MOV32ri), TmpGPR)
+                  .addImm(0)
+                  .setMIFlags(MachineInstr::MIFlag::NoMerge));
 
   const TargetRegisterInfo *TRI = &getRegisterInfo();
   auto SubReg = TRI->getSubReg(TmpGPR, X86::sub_8bit);
-  BuildMI(*MBB, MI, DL, get(X86::SETCCr))
-      .addReg(SubReg)
-      .addImm(CC)
-      .setMIFlags(MachineInstr::MIFlag::NoMerge);
+  recordInstr(BuildMI(*MBB, MI, DL, get(X86::SETCCr))
+                  .addReg(SubReg)
+                  .addImm(CC)
+                  .setMIFlags(MachineInstr::MIFlag::NoMerge));
 
   // Zero-extend byte to 32-bit register (movzbl %al, %eax)
-  BuildMI(*MBB, MI, DL, get(X86::MOVZX32rr8), TmpGPR)
-      .addReg(SubReg)
-      .setMIFlags(MachineInstr::MIFlag::NoMerge);
+  recordInstr(BuildMI(*MBB, MI, DL, get(X86::MOVZX32rr8), TmpGPR)
+                  .addReg(SubReg)
+                  .setMIFlags(MachineInstr::MIFlag::NoMerge));
 
   if (Instruction.UseBlendInstr && Subtarget.hasSSE41()) {
     // Shift left 31 bits to convert 1 -> 0x80000000, 0 -> 0x00000000 (shll $31,
     // %eax)
-    BuildMI(*MBB, MI, DL, get(X86::SHL32ri), TmpGPR).addReg(TmpGPR).addImm(31);
+    recordInstr(BuildMI(*MBB, MI, DL, get(X86::SHL32ri), TmpGPR)
+                    .addReg(TmpGPR)
+                    .addImm(31));
   } else {
     // Negate to convert 1 -> 0xFFFFFFFF, 0 -> 0x00000000 (negl %eax)
-    BuildMI(*MBB, MI, DL, get(X86::NEG32r), TmpGPR).addReg(TmpGPR);
+    recordInstr(BuildMI(*MBB, MI, DL, get(X86::NEG32r), TmpGPR)
+                    .addReg(TmpGPR));
   }
 
   // Broadcast to TmpX (vector mask)
-  BuildMI(*MBB, MI, DL, get(X86::PXORrr), MaskReg)
-      .addReg(MaskReg)
-      .addReg(MaskReg)
-      .setMIFlags(MachineInstr::MIFlag::NoMerge);
+  recordInstr(BuildMI(*MBB, MI, DL, get(X86::PXORrr), MaskReg)
+                  .addReg(MaskReg)
+                  .addReg(MaskReg)
+                  .setMIFlags(MachineInstr::MIFlag::NoMerge));
 
   // Move scalar mask to vector register
-  BuildMI(*MBB, MI, DL, get(Instruction.IntMoveOpc), MaskReg)
-      .addReg(TmpGPR)
-      .setMIFlags(MachineInstr::MIFlag::NoMerge);
+  recordInstr(BuildMI(*MBB, MI, DL, get(Instruction.IntMoveOpc), MaskReg)
+                  .addReg(TmpGPR)
+                  .setMIFlags(MachineInstr::MIFlag::NoMerge));
 
   if (Instruction.Use256) {
     // Broadcast to 256-bit vector register
-    BuildMI(*MBB, MI, DL, get(Instruction.BroadcastOpc), MaskReg)
-        .addReg(MaskReg)
-        .addImm(0)
-        .setMIFlags(MachineInstr::MIFlag::NoMerge);
+    recordInstr(BuildMI(*MBB, MI, DL, get(Instruction.BroadcastOpc), MaskReg)
+                    .addReg(MaskReg)
+                    .addImm(0)
+                    .setMIFlags(MachineInstr::MIFlag::NoMerge));
   } else {
     if (Subtarget.hasSSE2() || Subtarget.hasAVX()) {
-      BuildMI(*MBB, MI, DL, get(Instruction.BroadcastOpc), MaskReg)
-          .addReg(MaskReg)
-          .addImm(0x00)
-          .setMIFlags(MachineInstr::MIFlag::NoMerge);
+      recordInstr(BuildMI(*MBB, MI, DL, get(Instruction.BroadcastOpc), MaskReg)
+                      .addReg(MaskReg)
+                      .addImm(0x00)
+                      .setMIFlags(MachineInstr::MIFlag::NoMerge));
     } else {
-      BuildMI(*MBB, MI, DL, get(Instruction.BroadcastOpc), MaskReg)
-          .addReg(MaskReg)
-          .addReg(MaskReg)
-          .addImm(0x00)
-          .setMIFlags(MachineInstr::MIFlag::NoMerge);
+      recordInstr(BuildMI(*MBB, MI, DL, get(Instruction.BroadcastOpc), MaskReg)
+                      .addReg(MaskReg)
+                      .addReg(MaskReg)
+                      .addImm(0x00)
+                      .setMIFlags(MachineInstr::MIFlag::NoMerge));
     }
   }
 
@@ -750,9 +762,9 @@ bool X86InstrInfo::expandCtSelectVector(MachineInstr &MI) const {
 
       // if XMM0 is one of the source registers, it will not match with Dst
       // registers, so we need to move it to Dst register
-      BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), Dst)
-          .addReg(SrcXMM0)
-          .setMIFlags(MachineInstr::MIFlag::NoMerge);
+      recordInstr(BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), Dst)
+                      .addReg(SrcXMM0)
+                      .setMIFlags(MachineInstr::MIFlag::NoMerge));
 
       // update FalseVal and TrueVal to Dst register
       if (FalseVal == X86::XMM0)
@@ -770,9 +782,9 @@ bool X86InstrInfo::expandCtSelectVector(MachineInstr &MI) const {
 
       // if XMM0 is not allocated for any of the register, we stil need to save
       // and restore it after using as mask register
-      BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), Dst)
-          .addReg(X86::XMM0)
-          .setMIFlags(MachineInstr::MIFlag::NoMerge);
+      recordInstr(BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), Dst)
+                      .addReg(X86::XMM0)
+                      .setMIFlags(MachineInstr::MIFlag::NoMerge));
       SavedXMM0 = Dst;
       DidSaveXMM0 = true;
     }
@@ -780,75 +792,76 @@ bool X86InstrInfo::expandCtSelectVector(MachineInstr &MI) const {
     if (MaskReg != X86::XMM0) {
       // BLENDV uses XMM0 as implicit mask register
       // https://www.felixcloutier.com/x86/pblendvb
-      BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), X86::XMM0)
-          .addReg(MaskReg)
-          .setMIFlag(MachineInstr::MIFlag::NoMerge);
+      recordInstr(BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), X86::XMM0)
+                      .addReg(MaskReg)
+                      .setMIFlag(MachineInstr::MIFlag::NoMerge));
 
       // move FalseVal to mask (use MaskReg as the dst of the blend)
-      BuildMI(*MBB, MI, DL, get(X86::MOVAPSrr), MaskReg)
-          .addReg(FalseVal)
-          .setMIFlags(MachineInstr::MIFlag::NoMerge);
+      recordInstr(BuildMI(*MBB, MI, DL, get(X86::MOVAPSrr), MaskReg)
+                      .addReg(FalseVal)
+                      .setMIFlags(MachineInstr::MIFlag::NoMerge));
 
       // MaskReg := blend(MaskReg /*false*/, TrueVal /*true*/)  ; mask in
       // xmm0
-      BuildMI(*MBB, MI, DL, get(BlendOpc), MaskReg)
-          .addReg(MaskReg)
-          .addReg(TrueVal)
-          .addReg(X86::XMM0)
-          .setMIFlags(MachineInstr::MIFlag::NoMerge);
+      recordInstr(BuildMI(*MBB, MI, DL, get(BlendOpc), MaskReg)
+                      .addReg(MaskReg)
+                      .addReg(TrueVal)
+                      .addReg(X86::XMM0)
+                      .setMIFlags(MachineInstr::MIFlag::NoMerge));
 
       // restore XMM0 from SavedXMM0 if we saved it into Dst
       if (DidSaveXMM0) {
-        BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), X86::XMM0)
-            .addReg(SavedXMM0)
-            .setMIFlags(MachineInstr::MIFlag::NoMerge);
+        recordInstr(BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), X86::XMM0)
+                        .addReg(SavedXMM0)
+                        .setMIFlags(MachineInstr::MIFlag::NoMerge));
       }
       // dst = result (now in MaskReg)
-      BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), Dst)
-          .addReg(MaskReg)
-          .setMIFlags(MachineInstr::MIFlag::NoMerge);
+      recordInstr(BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), Dst)
+                      .addReg(MaskReg)
+                      .setMIFlags(MachineInstr::MIFlag::NoMerge));
     } else {
       // move FalseVal to Dst register since MaskReg is XMM0 and Dst is not
-      BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), Dst)
-          .addReg(FalseVal)
-          .setMIFlags(MachineInstr::MIFlag::NoMerge);
+      recordInstr(BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), Dst)
+                      .addReg(FalseVal)
+                      .setMIFlags(MachineInstr::MIFlag::NoMerge));
 
       // Dst := blend(Dst /*false*/, TrueVal /*true*/)  ; mask in
       // xmm0
-      BuildMI(*MBB, MI, DL, get(BlendOpc), Dst)
-          .addReg(Dst)
-          .addReg(TrueVal)
-          .addReg(X86::XMM0)
-          .setMIFlags(MachineInstr::MIFlag::NoMerge);
+      recordInstr(BuildMI(*MBB, MI, DL, get(BlendOpc), Dst)
+                      .addReg(Dst)
+                      .addReg(TrueVal)
+                      .addReg(X86::XMM0)
+                      .setMIFlags(MachineInstr::MIFlag::NoMerge));
     }
   } else {
 
     // dst = mask
-    BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), Dst)
-        .addReg(MaskReg)
-        .setMIFlags(MachineInstr::MIFlag::NoMerge);
+    recordInstr(BuildMI(*MBB, MI, DL, get(Instruction.MoveOpc), Dst)
+                    .addReg(MaskReg)
+                    .setMIFlags(MachineInstr::MIFlag::NoMerge));
 
     // mask &= true_val
-    BuildMI(*MBB, MI, DL, get(X86::PANDrr), MaskReg)
-        .addReg(MaskReg)
-        .addReg(TrueVal)
-        .setMIFlags(MachineInstr::MIFlag::NoMerge);
+    recordInstr(BuildMI(*MBB, MI, DL, get(X86::PANDrr), MaskReg)
+                    .addReg(MaskReg)
+                    .addReg(TrueVal)
+                    .setMIFlags(MachineInstr::MIFlag::NoMerge));
 
     // dst = ~mask & false_val
-    BuildMI(*MBB, MI, DL, get(X86::PANDNrr), Dst)
-        .addReg(Dst)
-        .addReg(FalseVal)
-        .setMIFlags(MachineInstr::MIFlag::NoMerge);
+    recordInstr(BuildMI(*MBB, MI, DL, get(X86::PANDNrr), Dst)
+                    .addReg(Dst)
+                    .addReg(FalseVal)
+                    .setMIFlags(MachineInstr::MIFlag::NoMerge));
 
     // dst |= mask; (mask & t) | (~mask & f)
-    BuildMI(*MBB, MI, DL, get(X86::PORrr), Dst)
-        .addReg(Dst)
-        .addReg(MaskReg)
-        .setMIFlags(MachineInstr::MIFlag::NoMerge);
+    recordInstr(BuildMI(*MBB, MI, DL, get(X86::PORrr), Dst)
+                    .addReg(Dst)
+                    .addReg(MaskReg)
+                    .setMIFlags(MachineInstr::MIFlag::NoMerge));
   }
 
-  // Add instruction bundling using the original pseudo as the exclusive end
-  finalizeBundle(*MBB, FirstNewMI->getIterator(), MI.getIterator());
+  assert(FirstInstr && LastInstr && "Expected at least one expanded instruction");
+  auto BundleEnd = LastInstr->getIterator();
+  finalizeBundle(*MBB, FirstInstr->getIterator(), std::next(BundleEnd));
 
   MI.eraseFromParent();
 

--- a/llvm/lib/Target/X86/X86InstrInfo.cpp
+++ b/llvm/lib/Target/X86/X86InstrInfo.cpp
@@ -668,7 +668,7 @@ bool X86InstrInfo::expandCtSelectVector(MachineInstr &MI) const {
   X86::CondCode CC = X86::CondCode(MI.getOperand(5).getImm()); // condition
 
   // Create scalar mask in tempGPR and broadcast to vector mask
-  BuildMI(*MBB, MI, DL, get(X86::MOV32ri), TmpGPR)
+  auto FirstNewMI = BuildMI(*MBB, MI, DL, get(X86::MOV32ri), TmpGPR)
       .addImm(0)
       .setMIFlags(MachineInstr::MIFlag::NoMerge);
 
@@ -847,10 +847,8 @@ bool X86InstrInfo::expandCtSelectVector(MachineInstr &MI) const {
         .setMIFlags(MachineInstr::MIFlag::NoMerge);
   }
 
-  // TODO: Bundle instructions to avoid future optimizations from breaking up
-  // the instructions sequence. However, bundled instructions disappears after
-  // unpack-mi-bundles pass. Look into the issue and fix it before enabling the
-  // instruction bundling.
+  // Add instruction bundling using the original pseudo as the exclusive end
+  finalizeBundle(*MBB, FirstNewMI->getIterator(), MI.getIterator());
 
   MI.eraseFromParent();
 

--- a/llvm/lib/Target/X86/X86TargetMachine.cpp
+++ b/llvm/lib/Target/X86/X86TargetMachine.cpp
@@ -664,7 +664,8 @@ void X86PassConfig::addPreEmitPass2() {
     return M->getModuleFlag("kcfi") ||
            (TT.isOSDarwin() &&
             (M->getFunction("objc_retainAutoreleasedReturnValue") ||
-             M->getFunction("objc_unsafeClaimAutoreleasedReturnValue")));
+             M->getFunction("objc_unsafeClaimAutoreleasedReturnValue"))) ||
+             F.hasFnAttribute("ct-select");
   }));
 }
 


### PR DESCRIPTION
This PR implements instruction bundling for constant-time select operations during post-register allocation expansion. The bundling ensures that the generated instruction sequences maintain their constant-time properties by preventing optimizations from reordering or separating.

## Key Changes
- **Function Attribute Marking**: Add `ct-select` attribute to functions using `llvm.ct.select` intrinsic
- **Instruction Bundling**: Bundle all expanded constant-time select instruction sequences
- **Cross-Architecture Support**: Enable bundling across ARM and x86 targets