### PR TITLE
Generate more efficient code when fp is from memory

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -37634,6 +37634,121 @@ emitCTSelectI386WithConditionMaterialization(MachineInstr &MI,
   return BB;
 }
 
+// Helper structure to hold memory operand information for FP loads
+struct FPLoadMemOperands {
+  bool IsValid = false;
+  unsigned BaseReg = 0;
+  int64_t ScaleVal = 1;
+  unsigned IndexReg = 0;
+  int64_t Disp = 0;
+  unsigned SegReg = 0;
+  int FrameIndex = -1;
+  bool IsFrameIndex = false;
+  int ConstantPoolIndex = -1;
+  bool IsConstantPool = false;
+  const GlobalValue *Global = nullptr;
+  int64_t GlobalOffset = 0;
+  bool IsGlobal = false;
+};
+
+// Check if a virtual register is defined by a simple FP load instruction
+// Returns the memory operands if it's a simple load, otherwise returns invalid
+static FPLoadMemOperands getFPLoadMemOperands(Register Reg,
+                                               MachineRegisterInfo &MRI,
+                                               unsigned ExpectedLoadOpcode) {
+  FPLoadMemOperands Result;
+
+  if (!Reg.isVirtual())
+    return Result;
+
+  MachineInstr *DefMI = MRI.getVRegDef(Reg);
+  if (!DefMI)
+    return Result;
+
+  // Check if it's the expected load opcode (e.g., LD_Fp32m, LD_Fp64m, LD_Fp80m)
+  if (DefMI->getOpcode() != ExpectedLoadOpcode)
+    return Result;
+
+  // Check that this is a simple load - not volatile, not atomic, etc.
+  // FP loads have hasSideEffects = 0 in their definition for simple loads
+  if (DefMI->hasOrderedMemoryRef())
+    return Result;
+
+  // The load should have a single def (the destination register) and memory operands
+  // Format: %reg = LD_Fpxxm <fi#N>, 1, %noreg, 0, %noreg
+  // or: %reg = LD_Fpxxm %base, scale, %index, disp, %segment
+  if (DefMI->getNumOperands() < 6)
+    return Result;
+
+  // Operand 0 is the destination, operands 1-5 are the memory reference
+  MachineOperand &BaseMO = DefMI->getOperand(1);
+  MachineOperand &ScaleMO = DefMI->getOperand(2);
+  MachineOperand &IndexMO = DefMI->getOperand(3);
+  MachineOperand &DispMO = DefMI->getOperand(4);
+  MachineOperand &SegMO = DefMI->getOperand(5);
+
+  // Check if this is a frame index load
+  if (BaseMO.isFI()) {
+    Result.IsValid = true;
+    Result.IsFrameIndex = true;
+    Result.FrameIndex = BaseMO.getIndex();
+    Result.ScaleVal = ScaleMO.getImm();
+    Result.IndexReg = IndexMO.getReg();
+    Result.Disp = DispMO.getImm();
+    Result.SegReg = SegMO.getReg();
+    return Result;
+  }
+
+  // Check if this is a constant pool load
+  // Format: %reg = LD_Fpxxm $noreg, 1, $noreg, %const.N, $noreg
+  if (BaseMO.isReg() && BaseMO.getReg() == X86::NoRegister &&
+      ScaleMO.isImm() && IndexMO.isReg() &&
+      IndexMO.getReg() == X86::NoRegister &&
+      DispMO.isCPI() && SegMO.isReg()) {
+    Result.IsValid = true;
+    Result.IsConstantPool = true;
+    Result.ConstantPoolIndex = DispMO.getIndex();
+    Result.ScaleVal = ScaleMO.getImm();
+    Result.IndexReg = IndexMO.getReg();
+    Result.Disp = 0;
+    Result.SegReg = SegMO.getReg();
+    return Result;
+  }
+
+  // Check if this is a global variable load
+  // Format: %reg = LD_Fpxxm $noreg, 1, $noreg, @global_name, $noreg
+  if (BaseMO.isReg() && BaseMO.getReg() == X86::NoRegister &&
+      ScaleMO.isImm() && IndexMO.isReg() &&
+      IndexMO.getReg() == X86::NoRegister &&
+      DispMO.isGlobal() && SegMO.isReg()) {
+    Result.IsValid = true;
+    Result.IsGlobal = true;
+    Result.Global = DispMO.getGlobal();
+    Result.GlobalOffset = DispMO.getOffset();
+    Result.ScaleVal = ScaleMO.getImm();
+    Result.IndexReg = IndexMO.getReg();
+    Result.Disp = 0;
+    Result.SegReg = SegMO.getReg();
+    return Result;
+  }
+
+  // Regular memory operands (e.g., pointer loads)
+  if (BaseMO.isReg() && ScaleMO.isImm() && IndexMO.isReg() &&
+      DispMO.isImm() && SegMO.isReg()) {
+    Result.IsValid = true;
+    Result.IsFrameIndex = false;
+    Result.IsConstantPool = false;
+    Result.BaseReg = BaseMO.getReg();
+    Result.ScaleVal = ScaleMO.getImm();
+    Result.IndexReg = IndexMO.getReg();
+    Result.Disp = DispMO.getImm();
+    Result.SegReg = SegMO.getReg();
+    return Result;
+  }
+
+  return Result;
+}
+
 static MachineBasicBlock *emitCTSelectI386WithFpType(MachineInstr &MI,
                                                      MachineBasicBlock *BB,
                                                      unsigned pseudoInstr) {
@@ -37659,6 +37774,85 @@ static MachineBasicBlock *emitCTSelectI386WithFpType(MachineInstr &MI,
   auto storeFpToSlot = [&](unsigned Opcode, int Slot, Register Reg) {
     addFrameReference(BuildMI(*BB, MI, MIMD, TII->get(Opcode)), Slot)
         .addReg(Reg, RegState::Kill);
+  };
+
+  // Helper to load integer from memory operands
+  auto loadIntFromMemOperands = [&](const FPLoadMemOperands &MemOps,
+                                     unsigned Offset) -> unsigned {
+    unsigned IntReg = MRI.createVirtualRegister(&X86::GR32RegClass);
+    MachineInstrBuilder MIB =
+        BuildMI(*BB, MI, MIMD, TII->get(X86::MOV32rm), IntReg);
+
+    if (MemOps.IsFrameIndex) {
+      // Frame index: addFrameIndex + scale + index + disp + segment
+      MIB.addFrameIndex(MemOps.FrameIndex)
+          .addImm(MemOps.ScaleVal)
+          .addReg(MemOps.IndexReg)
+          .addImm(MemOps.Disp + Offset)
+          .addReg(MemOps.SegReg);
+    } else if (MemOps.IsConstantPool) {
+      // Constant pool: base_reg + scale + index + CP_index + segment
+      // MOV32rm format: base, scale, index, displacement, segment
+      MIB.addReg(X86::NoRegister)  // Base register
+          .addImm(MemOps.ScaleVal)  // Scale
+          .addReg(MemOps.IndexReg)  // Index register
+          .addConstantPoolIndex(MemOps.ConstantPoolIndex, Offset)  // Displacement (CP index)
+          .addReg(MemOps.SegReg);  // Segment
+    } else if (MemOps.IsGlobal) {
+      // Global variable: base_reg + scale + index + global + segment
+      // MOV32rm format: base, scale, index, displacement, segment
+      MIB.addReg(X86::NoRegister)  // Base register
+          .addImm(MemOps.ScaleVal)  // Scale
+          .addReg(MemOps.IndexReg)  // Index register
+          .addGlobalAddress(MemOps.Global, MemOps.GlobalOffset + Offset)  // Displacement (global address)
+          .addReg(MemOps.SegReg);  // Segment
+    } else {
+      // Regular memory: base_reg + scale + index + disp + segment
+      MIB.addReg(MemOps.BaseReg)
+          .addImm(MemOps.ScaleVal)
+          .addReg(MemOps.IndexReg)
+          .addImm(MemOps.Disp + Offset)
+          .addReg(MemOps.SegReg);
+    }
+
+    return IntReg;
+  };
+
+  // Optimized path: load integers directly from memory when both operands are
+  // memory loads, avoiding FP register round-trip
+  auto emitCtSelectFromMemory = [&](unsigned NumValues,
+                                     const FPLoadMemOperands &TrueMemOps,
+                                     const FPLoadMemOperands &FalseMemOps,
+                                     int ResultSlot) {
+    for (unsigned Val = 0; Val < NumValues; ++Val) {
+      unsigned Offset = Val * RegSizeInByte;
+
+      // Load true and false values directly from their memory locations as integers
+      unsigned TrueIntReg = loadIntFromMemOperands(TrueMemOps, Offset);
+      unsigned FalseIntReg = loadIntFromMemOperands(FalseMemOps, Offset);
+
+      // Use CTSELECT_I386_INT_GR32 pseudo instruction for constant-time selection
+      unsigned ResultIntReg = MRI.createVirtualRegister(&X86::GR32RegClass);
+      unsigned TmpByteReg = MRI.createVirtualRegister(&X86::GR8RegClass);
+      unsigned TmpMaskReg = MRI.createVirtualRegister(&X86::GR32RegClass);
+
+      BuildMI(*BB, MI, MIMD, TII->get(X86::CTSELECT_I386_INT_GR32rr))
+          .addDef(ResultIntReg)    // dst (output)
+          .addDef(TmpByteReg)      // tmp_byte (output)
+          .addDef(TmpMaskReg)      // tmp_mask (output)
+          .addReg(FalseIntReg)     // src1 (input) - false value
+          .addReg(TrueIntReg)      // src2 (input) - true value
+          .addReg(CondByteReg);    // pre-materialized condition byte (input)
+
+      // Store result back to result slot
+      BuildMI(*BB, MI, MIMD, TII->get(X86::MOV32mr))
+          .addFrameIndex(ResultSlot)
+          .addImm(1)
+          .addReg(0)
+          .addImm(Offset)
+          .addReg(0)
+          .addReg(ResultIntReg, RegState::Kill);
+    }
   };
 
   auto emitCtSelectWithPseudo = [&](unsigned NumValues, int TrueSlot, int FalseSlot, int ResultSlot) {
@@ -37708,17 +37902,40 @@ static MachineBasicBlock *emitCTSelectI386WithFpType(MachineInstr &MI,
 
   switch (pseudoInstr) {
   case X86::CTSELECT_I386_FP32rr: {
-    // Allocate stack slots (4 bytes for f32)
+    // Check if both operands are simple memory loads
+    FPLoadMemOperands TrueMemOps =
+        getFPLoadMemOperands(TrueReg, MRI, X86::LD_Fp32m);
+    FPLoadMemOperands FalseMemOps =
+        getFPLoadMemOperands(FalseReg, MRI, X86::LD_Fp32m);
+
     int ResultSlot = MFI.CreateStackObject(RegSizeInByte, Align(4), false);
-    int TrueSlot = MFI.CreateStackObject(RegSizeInByte, Align(4), false);
-    int FalseSlot = MFI.CreateStackObject(RegSizeInByte, Align(4), false);
 
-    // Store f32 values to stack
-    storeFpToSlot(X86::ST_Fp32m, TrueSlot, TrueReg);
-    storeFpToSlot(X86::ST_Fp32m, FalseSlot, FalseReg);
+    if (TrueMemOps.IsValid && FalseMemOps.IsValid) {
+      // Optimized path: load directly from memory as integers
+      // Works for both frame index loads (stack parameters) and
+      // constant pool loads (constants)
+      emitCtSelectFromMemory(1, TrueMemOps, FalseMemOps, ResultSlot);
 
-    // Use pseudo instruction for selection (1 x 32-bit value)
-    emitCtSelectWithPseudo(1, TrueSlot, FalseSlot, ResultSlot);
+      // Erase the original FP load instructions since we're not using them
+      // and have loaded the data directly as integers instead
+      if (MRI.hasOneUse(TrueReg)) {
+        if (MachineInstr *TrueDefMI = MRI.getVRegDef(TrueReg))
+          TrueDefMI->eraseFromParent();
+      }
+      if (MRI.hasOneUse(FalseReg)) {
+        if (MachineInstr *FalseDefMI = MRI.getVRegDef(FalseReg))
+          FalseDefMI->eraseFromParent();
+      }
+    } else {
+      // General path: spill FP registers to stack first
+      int TrueSlot = MFI.CreateStackObject(RegSizeInByte, Align(4), false);
+      int FalseSlot = MFI.CreateStackObject(RegSizeInByte, Align(4), false);
+
+      storeFpToSlot(X86::ST_Fp32m, TrueSlot, TrueReg);
+      storeFpToSlot(X86::ST_Fp32m, FalseSlot, FalseReg);
+
+      emitCtSelectWithPseudo(1, TrueSlot, FalseSlot, ResultSlot);
+    }
 
     // Load result back as f32
     addFrameReference(BuildMI(*BB, MI, MIMD, TII->get(X86::LD_Fp32m), DestReg),
@@ -37727,17 +37944,42 @@ static MachineBasicBlock *emitCTSelectI386WithFpType(MachineInstr &MI,
   }
   case X86::CTSELECT_I386_FP64rr: {
     unsigned StackSlotSize = 8;
-    // Allocate stack slots (8 bytes for f64)
-    int TrueSlot = MFI.CreateStackObject(StackSlotSize, Align(4), false);
-    int FalseSlot = MFI.CreateStackObject(StackSlotSize, Align(4), false);
+
+    // Check if both operands are simple memory loads
+    FPLoadMemOperands TrueMemOps =
+        getFPLoadMemOperands(TrueReg, MRI, X86::LD_Fp64m);
+    FPLoadMemOperands FalseMemOps =
+        getFPLoadMemOperands(FalseReg, MRI, X86::LD_Fp64m);
+
     int ResultSlot = MFI.CreateStackObject(StackSlotSize, Align(4), false);
 
-    // Store f64 values to stack
-    storeFpToSlot(X86::ST_Fp64m, TrueSlot, TrueReg);
-    storeFpToSlot(X86::ST_Fp64m, FalseSlot, FalseReg);
+    if (TrueMemOps.IsValid && FalseMemOps.IsValid) {
+      // Optimized path: load directly from memory as integers
+      // Works for both frame index loads (stack parameters) and
+      // constant pool loads (constants)
+      emitCtSelectFromMemory(StackSlotSize / RegSizeInByte, TrueMemOps,
+                             FalseMemOps, ResultSlot);
 
-    // Use pseudo instruction for selection (2 x 32-bit values)
-    emitCtSelectWithPseudo(StackSlotSize/RegSizeInByte, TrueSlot, FalseSlot, ResultSlot);
+      // Erase the original FP load instructions since we're not using them
+      if (MRI.hasOneUse(TrueReg)) {
+        if (MachineInstr *TrueDefMI = MRI.getVRegDef(TrueReg))
+          TrueDefMI->eraseFromParent();
+      }
+      if (MRI.hasOneUse(FalseReg)) {
+        if (MachineInstr *FalseDefMI = MRI.getVRegDef(FalseReg))
+          FalseDefMI->eraseFromParent();
+      }
+    } else {
+      // General path: spill FP registers to stack first
+      int TrueSlot = MFI.CreateStackObject(StackSlotSize, Align(4), false);
+      int FalseSlot = MFI.CreateStackObject(StackSlotSize, Align(4), false);
+
+      storeFpToSlot(X86::ST_Fp64m, TrueSlot, TrueReg);
+      storeFpToSlot(X86::ST_Fp64m, FalseSlot, FalseReg);
+
+      emitCtSelectWithPseudo(StackSlotSize / RegSizeInByte, TrueSlot, FalseSlot,
+                             ResultSlot);
+    }
 
     // Load result back as f64
     addFrameReference(BuildMI(*BB, MI, MIMD, TII->get(X86::LD_Fp64m), DestReg),
@@ -37745,18 +37987,44 @@ static MachineBasicBlock *emitCTSelectI386WithFpType(MachineInstr &MI,
     break;
   }
   case X86::CTSELECT_I386_FP80rr: {
-    // Allocate stack slots (12 bytes for f80 - 80-bit = 10 bytes, aligned to 12)
+    // f80 is 80 bits (10 bytes), but stored with 12-byte alignment
     unsigned StackObjectSize = 12;
-    int TrueSlot = MFI.CreateStackObject(StackObjectSize, Align(4), false);
-    int FalseSlot = MFI.CreateStackObject(StackObjectSize, Align(4), false);
+
+    // Check if both operands are simple memory loads
+    FPLoadMemOperands TrueMemOps =
+        getFPLoadMemOperands(TrueReg, MRI, X86::LD_Fp80m);
+    FPLoadMemOperands FalseMemOps =
+        getFPLoadMemOperands(FalseReg, MRI, X86::LD_Fp80m);
+
     int ResultSlot = MFI.CreateStackObject(StackObjectSize, Align(4), false);
 
-    // Store f80 values to stack
-    storeFpToSlot(X86::ST_FpP80m, TrueSlot, TrueReg);
-    storeFpToSlot(X86::ST_FpP80m, FalseSlot, FalseReg);
+    if (TrueMemOps.IsValid && FalseMemOps.IsValid) {
+      // Optimized path: load directly from memory as integers
+      // Works for both frame index loads (stack parameters) and
+      // constant pool loads (constants)
+      emitCtSelectFromMemory(StackObjectSize / RegSizeInByte, TrueMemOps,
+                             FalseMemOps, ResultSlot);
 
-    // Use pseudo instruction for selection (3 x 32-bit values)
-    emitCtSelectWithPseudo(StackObjectSize/RegSizeInByte, TrueSlot, FalseSlot, ResultSlot);
+      // Erase the original FP load instructions since we're not using them
+      if (MRI.hasOneUse(TrueReg)) {
+        if (MachineInstr *TrueDefMI = MRI.getVRegDef(TrueReg))
+          TrueDefMI->eraseFromParent();
+      }
+      if (MRI.hasOneUse(FalseReg)) {
+        if (MachineInstr *FalseDefMI = MRI.getVRegDef(FalseReg))
+          FalseDefMI->eraseFromParent();
+      }
+    } else {
+      // General path: spill FP registers to stack first
+      int TrueSlot = MFI.CreateStackObject(StackObjectSize, Align(4), false);
+      int FalseSlot = MFI.CreateStackObject(StackObjectSize, Align(4), false);
+
+      storeFpToSlot(X86::ST_FpP80m, TrueSlot, TrueReg);
+      storeFpToSlot(X86::ST_FpP80m, FalseSlot, FalseReg);
+
+      emitCtSelectWithPseudo(StackObjectSize / RegSizeInByte, TrueSlot,
+                             FalseSlot, ResultSlot);
+    }
 
     // Load result back as f80
     addFrameReference(BuildMI(*BB, MI, MIMD, TII->get(X86::LD_Fp80m), DestReg),

--- a/llvm/test/CodeGen/X86/ctselect-edge-cases.ll
+++ b/llvm/test/CodeGen/X86/ctselect-edge-cases.ll
@@ -101,15 +101,34 @@ define float @test_ctselect_f32_special_values(i1 %cond) {
 ;
 ; X32-LABEL: test_ctselect_f32_special_values:
 ; X32:       # %bb.0:
+; X32-NEXT:    pushl %edi
+; X32-NEXT:    .cfi_def_cfa_offset 8
+; X32-NEXT:    pushl %esi
+; X32-NEXT:    .cfi_def_cfa_offset 12
+; X32-NEXT:    pushl %eax
+; X32-NEXT:    .cfi_def_cfa_offset 16
+; X32-NEXT:    .cfi_offset %esi, -12
+; X32-NEXT:    .cfi_offset %edi, -8
 ; X32-NEXT:    testb $1, {{[0-9]+}}(%esp)
-; X32-NEXT:    flds {{\.?LCPI[0-9]+_[0-9]+}}
-; X32-NEXT:    flds {{\.?LCPI[0-9]+_[0-9]+}}
-; X32-NEXT:    jne .LBB3_2
-; X32-NEXT:  # %bb.1:
-; X32-NEXT:    fstp %st(1)
-; X32-NEXT:    fldz
-; X32-NEXT:  .LBB3_2:
-; X32-NEXT:    fstp %st(0)
+; X32-NEXT:    sete %al
+; X32-NEXT:    movl {{\.?LCPI[0-9]+_[0-9]+}}, %ecx
+; X32-NEXT:    movl {{\.?LCPI[0-9]+_[0-9]+}}, %edx
+; X32-NEXT:    movb %al, %ah
+; X32-NEXT:    movzbl %ah, %edi
+; X32-NEXT:    negl %edi
+; X32-NEXT:    movl %edx, %esi
+; X32-NEXT:    andl %edi, %esi
+; X32-NEXT:    notl %edi
+; X32-NEXT:    andl %ecx, %edi
+; X32-NEXT:    orl %edi, %esi
+; X32-NEXT:    movl %esi, (%esp)
+; X32-NEXT:    flds (%esp)
+; X32-NEXT:    addl $4, %esp
+; X32-NEXT:    .cfi_def_cfa_offset 12
+; X32-NEXT:    popl %esi
+; X32-NEXT:    .cfi_def_cfa_offset 8
+; X32-NEXT:    popl %edi
+; X32-NEXT:    .cfi_def_cfa_offset 4
 ; X32-NEXT:    retl
   %result = call float @llvm.ct.select.f32(i1 %cond, float 0x7FF8000000000000, float 0x7FF0000000000000)
   ret float %result
@@ -127,15 +146,50 @@ define double @test_ctselect_f64_special_values(i1 %cond) {
 ;
 ; X32-LABEL: test_ctselect_f64_special_values:
 ; X32:       # %bb.0:
+; X32-NEXT:    pushl %edi
+; X32-NEXT:    .cfi_def_cfa_offset 8
+; X32-NEXT:    pushl %esi
+; X32-NEXT:    .cfi_def_cfa_offset 12
+; X32-NEXT:    subl $24, %esp
+; X32-NEXT:    .cfi_def_cfa_offset 36
+; X32-NEXT:    .cfi_offset %esi, -12
+; X32-NEXT:    .cfi_offset %edi, -8
 ; X32-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; X32-NEXT:    flds {{\.?LCPI[0-9]+_[0-9]+}}
 ; X32-NEXT:    flds {{\.?LCPI[0-9]+_[0-9]+}}
-; X32-NEXT:    jne .LBB4_2
-; X32-NEXT:  # %bb.1:
-; X32-NEXT:    fstp %st(1)
-; X32-NEXT:    fldz
-; X32-NEXT:  .LBB4_2:
-; X32-NEXT:    fstp %st(0)
+; X32-NEXT:    sete %al
+; X32-NEXT:    fxch %st(1)
+; X32-NEXT:    fstpl {{[0-9]+}}(%esp)
+; X32-NEXT:    fstpl (%esp)
+; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X32-NEXT:    movl (%esp), %edx
+; X32-NEXT:    movb %al, %ah
+; X32-NEXT:    movzbl %ah, %edi
+; X32-NEXT:    negl %edi
+; X32-NEXT:    movl %edx, %esi
+; X32-NEXT:    andl %edi, %esi
+; X32-NEXT:    notl %edi
+; X32-NEXT:    andl %ecx, %edi
+; X32-NEXT:    orl %edi, %esi
+; X32-NEXT:    movl %esi, {{[0-9]+}}(%esp)
+; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X32-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X32-NEXT:    movb %al, %ah
+; X32-NEXT:    movzbl %ah, %edi
+; X32-NEXT:    negl %edi
+; X32-NEXT:    movl %edx, %esi
+; X32-NEXT:    andl %edi, %esi
+; X32-NEXT:    notl %edi
+; X32-NEXT:    andl %ecx, %edi
+; X32-NEXT:    orl %edi, %esi
+; X32-NEXT:    movl %esi, {{[0-9]+}}(%esp)
+; X32-NEXT:    fldl {{[0-9]+}}(%esp)
+; X32-NEXT:    addl $24, %esp
+; X32-NEXT:    .cfi_def_cfa_offset 12
+; X32-NEXT:    popl %esi
+; X32-NEXT:    .cfi_def_cfa_offset 8
+; X32-NEXT:    popl %edi
+; X32-NEXT:    .cfi_def_cfa_offset 4
 ; X32-NEXT:    retl
   %result = call double @llvm.ct.select.f64(i1 %cond, double 0x7FF8000000000000, double 0x7FF0000000000000)
   ret double %result

--- a/llvm/test/CodeGen/X86/ctselect-i386-fp.ll
+++ b/llvm/test/CodeGen/X86/ctselect-i386-fp.ll
@@ -15,16 +15,11 @@ define float @test_ctselect_f32_basic(i1 %cond, float %a, float %b) nounwind {
 ; I386-NOCMOV:       # %bb.0:
 ; I386-NOCMOV-NEXT:    pushl %edi
 ; I386-NOCMOV-NEXT:    pushl %esi
-; I386-NOCMOV-NEXT:    subl $12, %esp
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; I386-NOCMOV-NEXT:    pushl %eax
 ; I386-NOCMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    sete %al
-; I386-NOCMOV-NEXT:    fxch %st(1)
-; I386-NOCMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fstps (%esp)
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; I386-NOCMOV-NEXT:    movl (%esp), %edx
+; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-NOCMOV-NEXT:    movb %al, %ah
 ; I386-NOCMOV-NEXT:    movzbl %ah, %edi
 ; I386-NOCMOV-NEXT:    negl %edi
@@ -33,9 +28,9 @@ define float @test_ctselect_f32_basic(i1 %cond, float %a, float %b) nounwind {
 ; I386-NOCMOV-NEXT:    notl %edi
 ; I386-NOCMOV-NEXT:    andl %ecx, %edi
 ; I386-NOCMOV-NEXT:    orl %edi, %esi
-; I386-NOCMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    addl $12, %esp
+; I386-NOCMOV-NEXT:    movl %esi, (%esp)
+; I386-NOCMOV-NEXT:    flds (%esp)
+; I386-NOCMOV-NEXT:    addl $4, %esp
 ; I386-NOCMOV-NEXT:    popl %esi
 ; I386-NOCMOV-NEXT:    popl %edi
 ; I386-NOCMOV-NEXT:    retl
@@ -44,16 +39,11 @@ define float @test_ctselect_f32_basic(i1 %cond, float %a, float %b) nounwind {
 ; I386-CMOV:       # %bb.0:
 ; I386-CMOV-NEXT:    pushl %edi
 ; I386-CMOV-NEXT:    pushl %esi
-; I386-CMOV-NEXT:    subl $12, %esp
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; I386-CMOV-NEXT:    pushl %eax
 ; I386-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    sete %al
-; I386-CMOV-NEXT:    fxch %st(1)
-; I386-CMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fstps (%esp)
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; I386-CMOV-NEXT:    movl (%esp), %edx
+; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-CMOV-NEXT:    movb %al, %ah
 ; I386-CMOV-NEXT:    movzbl %ah, %edi
 ; I386-CMOV-NEXT:    negl %edi
@@ -62,9 +52,9 @@ define float @test_ctselect_f32_basic(i1 %cond, float %a, float %b) nounwind {
 ; I386-CMOV-NEXT:    notl %edi
 ; I386-CMOV-NEXT:    andl %ecx, %edi
 ; I386-CMOV-NEXT:    orl %edi, %esi
-; I386-CMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    addl $12, %esp
+; I386-CMOV-NEXT:    movl %esi, (%esp)
+; I386-CMOV-NEXT:    flds (%esp)
+; I386-CMOV-NEXT:    addl $4, %esp
 ; I386-CMOV-NEXT:    popl %esi
 ; I386-CMOV-NEXT:    popl %edi
 ; I386-CMOV-NEXT:    retl
@@ -78,9 +68,7 @@ define float @test_ctselect_f32_eq(float %x, float %y, float %a, float %b) nounw
 ; I386-NOCMOV:       # %bb.0:
 ; I386-NOCMOV-NEXT:    pushl %edi
 ; I386-NOCMOV-NEXT:    pushl %esi
-; I386-NOCMOV-NEXT:    subl $12, %esp
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; I386-NOCMOV-NEXT:    pushl %eax
 ; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    fucompp
@@ -91,11 +79,8 @@ define float @test_ctselect_f32_eq(float %x, float %y, float %a, float %b) nounw
 ; I386-NOCMOV-NEXT:    sete %cl
 ; I386-NOCMOV-NEXT:    testb %al, %cl
 ; I386-NOCMOV-NEXT:    sete %al
-; I386-NOCMOV-NEXT:    fxch %st(1)
-; I386-NOCMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fstps (%esp)
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; I386-NOCMOV-NEXT:    movl (%esp), %edx
+; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-NOCMOV-NEXT:    movb %al, %ah
 ; I386-NOCMOV-NEXT:    movzbl %ah, %edi
 ; I386-NOCMOV-NEXT:    negl %edi
@@ -104,9 +89,9 @@ define float @test_ctselect_f32_eq(float %x, float %y, float %a, float %b) nounw
 ; I386-NOCMOV-NEXT:    notl %edi
 ; I386-NOCMOV-NEXT:    andl %ecx, %edi
 ; I386-NOCMOV-NEXT:    orl %edi, %esi
-; I386-NOCMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    addl $12, %esp
+; I386-NOCMOV-NEXT:    movl %esi, (%esp)
+; I386-NOCMOV-NEXT:    flds (%esp)
+; I386-NOCMOV-NEXT:    addl $4, %esp
 ; I386-NOCMOV-NEXT:    popl %esi
 ; I386-NOCMOV-NEXT:    popl %edi
 ; I386-NOCMOV-NEXT:    retl
@@ -115,9 +100,7 @@ define float @test_ctselect_f32_eq(float %x, float %y, float %a, float %b) nounw
 ; I386-CMOV:       # %bb.0:
 ; I386-CMOV-NEXT:    pushl %edi
 ; I386-CMOV-NEXT:    pushl %esi
-; I386-CMOV-NEXT:    subl $12, %esp
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; I386-CMOV-NEXT:    pushl %eax
 ; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    fucompi %st(1), %st
@@ -126,11 +109,8 @@ define float @test_ctselect_f32_eq(float %x, float %y, float %a, float %b) nounw
 ; I386-CMOV-NEXT:    sete %cl
 ; I386-CMOV-NEXT:    testb %al, %cl
 ; I386-CMOV-NEXT:    sete %al
-; I386-CMOV-NEXT:    fxch %st(1)
-; I386-CMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fstps (%esp)
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; I386-CMOV-NEXT:    movl (%esp), %edx
+; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-CMOV-NEXT:    movb %al, %ah
 ; I386-CMOV-NEXT:    movzbl %ah, %edi
 ; I386-CMOV-NEXT:    negl %edi
@@ -139,9 +119,9 @@ define float @test_ctselect_f32_eq(float %x, float %y, float %a, float %b) nounw
 ; I386-CMOV-NEXT:    notl %edi
 ; I386-CMOV-NEXT:    andl %ecx, %edi
 ; I386-CMOV-NEXT:    orl %edi, %esi
-; I386-CMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    addl $12, %esp
+; I386-CMOV-NEXT:    movl %esi, (%esp)
+; I386-CMOV-NEXT:    flds (%esp)
+; I386-CMOV-NEXT:    addl $4, %esp
 ; I386-CMOV-NEXT:    popl %esi
 ; I386-CMOV-NEXT:    popl %edi
 ; I386-CMOV-NEXT:    retl
@@ -156,14 +136,9 @@ define double @test_ctselect_f64_basic(i1 %cond, double %a, double %b) nounwind 
 ; I386-NOCMOV:       # %bb.0:
 ; I386-NOCMOV-NEXT:    pushl %edi
 ; I386-NOCMOV-NEXT:    pushl %esi
-; I386-NOCMOV-NEXT:    subl $24, %esp
-; I386-NOCMOV-NEXT:    fldl {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fldl {{[0-9]+}}(%esp)
+; I386-NOCMOV-NEXT:    subl $8, %esp
 ; I386-NOCMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    sete %al
-; I386-NOCMOV-NEXT:    fxch %st(1)
-; I386-NOCMOV-NEXT:    fstpl {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fstpl {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-NOCMOV-NEXT:    movb %al, %ah
@@ -187,7 +162,7 @@ define double @test_ctselect_f64_basic(i1 %cond, double %a, double %b) nounwind 
 ; I386-NOCMOV-NEXT:    orl %edi, %esi
 ; I386-NOCMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    fldl (%esp)
-; I386-NOCMOV-NEXT:    addl $24, %esp
+; I386-NOCMOV-NEXT:    addl $8, %esp
 ; I386-NOCMOV-NEXT:    popl %esi
 ; I386-NOCMOV-NEXT:    popl %edi
 ; I386-NOCMOV-NEXT:    retl
@@ -196,14 +171,9 @@ define double @test_ctselect_f64_basic(i1 %cond, double %a, double %b) nounwind 
 ; I386-CMOV:       # %bb.0:
 ; I386-CMOV-NEXT:    pushl %edi
 ; I386-CMOV-NEXT:    pushl %esi
-; I386-CMOV-NEXT:    subl $24, %esp
-; I386-CMOV-NEXT:    fldl {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fldl {{[0-9]+}}(%esp)
+; I386-CMOV-NEXT:    subl $8, %esp
 ; I386-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    sete %al
-; I386-CMOV-NEXT:    fxch %st(1)
-; I386-CMOV-NEXT:    fstpl {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fstpl {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-CMOV-NEXT:    movb %al, %ah
@@ -227,7 +197,7 @@ define double @test_ctselect_f64_basic(i1 %cond, double %a, double %b) nounwind 
 ; I386-CMOV-NEXT:    orl %edi, %esi
 ; I386-CMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    fldl (%esp)
-; I386-CMOV-NEXT:    addl $24, %esp
+; I386-CMOV-NEXT:    addl $8, %esp
 ; I386-CMOV-NEXT:    popl %esi
 ; I386-CMOV-NEXT:    popl %edi
 ; I386-CMOV-NEXT:    retl
@@ -241,14 +211,9 @@ define x86_fp80 @test_ctselect_f80_basic(i1 %cond, x86_fp80 %a, x86_fp80 %b) nou
 ; I386-NOCMOV:       # %bb.0:
 ; I386-NOCMOV-NEXT:    pushl %edi
 ; I386-NOCMOV-NEXT:    pushl %esi
-; I386-NOCMOV-NEXT:    subl $36, %esp
-; I386-NOCMOV-NEXT:    fldt {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fldt {{[0-9]+}}(%esp)
+; I386-NOCMOV-NEXT:    subl $12, %esp
 ; I386-NOCMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    sete %al
-; I386-NOCMOV-NEXT:    fxch %st(1)
-; I386-NOCMOV-NEXT:    fstpt {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fstpt {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-NOCMOV-NEXT:    movb %al, %ah
@@ -283,7 +248,7 @@ define x86_fp80 @test_ctselect_f80_basic(i1 %cond, x86_fp80 %a, x86_fp80 %b) nou
 ; I386-NOCMOV-NEXT:    orl %edi, %esi
 ; I386-NOCMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    fldt (%esp)
-; I386-NOCMOV-NEXT:    addl $36, %esp
+; I386-NOCMOV-NEXT:    addl $12, %esp
 ; I386-NOCMOV-NEXT:    popl %esi
 ; I386-NOCMOV-NEXT:    popl %edi
 ; I386-NOCMOV-NEXT:    retl
@@ -292,14 +257,9 @@ define x86_fp80 @test_ctselect_f80_basic(i1 %cond, x86_fp80 %a, x86_fp80 %b) nou
 ; I386-CMOV:       # %bb.0:
 ; I386-CMOV-NEXT:    pushl %edi
 ; I386-CMOV-NEXT:    pushl %esi
-; I386-CMOV-NEXT:    subl $36, %esp
-; I386-CMOV-NEXT:    fldt {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fldt {{[0-9]+}}(%esp)
+; I386-CMOV-NEXT:    subl $12, %esp
 ; I386-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    sete %al
-; I386-CMOV-NEXT:    fxch %st(1)
-; I386-CMOV-NEXT:    fstpt {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fstpt {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-CMOV-NEXT:    movb %al, %ah
@@ -334,7 +294,7 @@ define x86_fp80 @test_ctselect_f80_basic(i1 %cond, x86_fp80 %a, x86_fp80 %b) nou
 ; I386-CMOV-NEXT:    orl %edi, %esi
 ; I386-CMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    fldt (%esp)
-; I386-CMOV-NEXT:    addl $36, %esp
+; I386-CMOV-NEXT:    addl $12, %esp
 ; I386-CMOV-NEXT:    popl %esi
 ; I386-CMOV-NEXT:    popl %edi
 ; I386-CMOV-NEXT:    retl
@@ -348,9 +308,7 @@ define float @test_ctselect_f32_gt(float %x, float %y, float %a, float %b) nounw
 ; I386-NOCMOV:       # %bb.0:
 ; I386-NOCMOV-NEXT:    pushl %edi
 ; I386-NOCMOV-NEXT:    pushl %esi
-; I386-NOCMOV-NEXT:    subl $12, %esp
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; I386-NOCMOV-NEXT:    pushl %eax
 ; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    fucompp
@@ -360,11 +318,8 @@ define float @test_ctselect_f32_gt(float %x, float %y, float %a, float %b) nounw
 ; I386-NOCMOV-NEXT:    seta %al
 ; I386-NOCMOV-NEXT:    testb %al, %al
 ; I386-NOCMOV-NEXT:    sete %al
-; I386-NOCMOV-NEXT:    fxch %st(1)
-; I386-NOCMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fstps (%esp)
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; I386-NOCMOV-NEXT:    movl (%esp), %edx
+; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-NOCMOV-NEXT:    movb %al, %ah
 ; I386-NOCMOV-NEXT:    movzbl %ah, %edi
 ; I386-NOCMOV-NEXT:    negl %edi
@@ -373,9 +328,9 @@ define float @test_ctselect_f32_gt(float %x, float %y, float %a, float %b) nounw
 ; I386-NOCMOV-NEXT:    notl %edi
 ; I386-NOCMOV-NEXT:    andl %ecx, %edi
 ; I386-NOCMOV-NEXT:    orl %edi, %esi
-; I386-NOCMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    addl $12, %esp
+; I386-NOCMOV-NEXT:    movl %esi, (%esp)
+; I386-NOCMOV-NEXT:    flds (%esp)
+; I386-NOCMOV-NEXT:    addl $4, %esp
 ; I386-NOCMOV-NEXT:    popl %esi
 ; I386-NOCMOV-NEXT:    popl %edi
 ; I386-NOCMOV-NEXT:    retl
@@ -384,9 +339,7 @@ define float @test_ctselect_f32_gt(float %x, float %y, float %a, float %b) nounw
 ; I386-CMOV:       # %bb.0:
 ; I386-CMOV-NEXT:    pushl %edi
 ; I386-CMOV-NEXT:    pushl %esi
-; I386-CMOV-NEXT:    subl $12, %esp
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; I386-CMOV-NEXT:    pushl %eax
 ; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    fucompi %st(1), %st
@@ -394,11 +347,8 @@ define float @test_ctselect_f32_gt(float %x, float %y, float %a, float %b) nounw
 ; I386-CMOV-NEXT:    seta %al
 ; I386-CMOV-NEXT:    testb %al, %al
 ; I386-CMOV-NEXT:    sete %al
-; I386-CMOV-NEXT:    fxch %st(1)
-; I386-CMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fstps (%esp)
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; I386-CMOV-NEXT:    movl (%esp), %edx
+; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-CMOV-NEXT:    movb %al, %ah
 ; I386-CMOV-NEXT:    movzbl %ah, %edi
 ; I386-CMOV-NEXT:    negl %edi
@@ -407,9 +357,9 @@ define float @test_ctselect_f32_gt(float %x, float %y, float %a, float %b) nounw
 ; I386-CMOV-NEXT:    notl %edi
 ; I386-CMOV-NEXT:    andl %ecx, %edi
 ; I386-CMOV-NEXT:    orl %edi, %esi
-; I386-CMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    addl $12, %esp
+; I386-CMOV-NEXT:    movl %esi, (%esp)
+; I386-CMOV-NEXT:    flds (%esp)
+; I386-CMOV-NEXT:    addl $4, %esp
 ; I386-CMOV-NEXT:    popl %esi
 ; I386-CMOV-NEXT:    popl %edi
 ; I386-CMOV-NEXT:    retl
@@ -424,16 +374,11 @@ define float @test_ctselect_f32_no_branches(i1 %cond, float %a, float %b) nounwi
 ; I386-NOCMOV:       # %bb.0:
 ; I386-NOCMOV-NEXT:    pushl %edi
 ; I386-NOCMOV-NEXT:    pushl %esi
-; I386-NOCMOV-NEXT:    subl $12, %esp
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; I386-NOCMOV-NEXT:    pushl %eax
 ; I386-NOCMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    sete %al
-; I386-NOCMOV-NEXT:    fxch %st(1)
-; I386-NOCMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fstps (%esp)
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; I386-NOCMOV-NEXT:    movl (%esp), %edx
+; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-NOCMOV-NEXT:    movb %al, %ah
 ; I386-NOCMOV-NEXT:    movzbl %ah, %edi
 ; I386-NOCMOV-NEXT:    negl %edi
@@ -442,9 +387,9 @@ define float @test_ctselect_f32_no_branches(i1 %cond, float %a, float %b) nounwi
 ; I386-NOCMOV-NEXT:    notl %edi
 ; I386-NOCMOV-NEXT:    andl %ecx, %edi
 ; I386-NOCMOV-NEXT:    orl %edi, %esi
-; I386-NOCMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    addl $12, %esp
+; I386-NOCMOV-NEXT:    movl %esi, (%esp)
+; I386-NOCMOV-NEXT:    flds (%esp)
+; I386-NOCMOV-NEXT:    addl $4, %esp
 ; I386-NOCMOV-NEXT:    popl %esi
 ; I386-NOCMOV-NEXT:    popl %edi
 ; I386-NOCMOV-NEXT:    retl
@@ -453,16 +398,11 @@ define float @test_ctselect_f32_no_branches(i1 %cond, float %a, float %b) nounwi
 ; I386-CMOV:       # %bb.0:
 ; I386-CMOV-NEXT:    pushl %edi
 ; I386-CMOV-NEXT:    pushl %esi
-; I386-CMOV-NEXT:    subl $12, %esp
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; I386-CMOV-NEXT:    pushl %eax
 ; I386-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    sete %al
-; I386-CMOV-NEXT:    fxch %st(1)
-; I386-CMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fstps (%esp)
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; I386-CMOV-NEXT:    movl (%esp), %edx
+; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-CMOV-NEXT:    movb %al, %ah
 ; I386-CMOV-NEXT:    movzbl %ah, %edi
 ; I386-CMOV-NEXT:    negl %edi
@@ -471,9 +411,9 @@ define float @test_ctselect_f32_no_branches(i1 %cond, float %a, float %b) nounwi
 ; I386-CMOV-NEXT:    notl %edi
 ; I386-CMOV-NEXT:    andl %ecx, %edi
 ; I386-CMOV-NEXT:    orl %edi, %esi
-; I386-CMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    addl $12, %esp
+; I386-CMOV-NEXT:    movl %esi, (%esp)
+; I386-CMOV-NEXT:    flds (%esp)
+; I386-CMOV-NEXT:    addl $4, %esp
 ; I386-CMOV-NEXT:    popl %esi
 ; I386-CMOV-NEXT:    popl %edi
 ; I386-CMOV-NEXT:    retl
@@ -487,16 +427,11 @@ define float @test_ctselect_f32_bundled(i1 %cond, float %a, float %b) nounwind {
 ; I386-NOCMOV:       # %bb.0:
 ; I386-NOCMOV-NEXT:    pushl %edi
 ; I386-NOCMOV-NEXT:    pushl %esi
-; I386-NOCMOV-NEXT:    subl $12, %esp
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; I386-NOCMOV-NEXT:    pushl %eax
 ; I386-NOCMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    sete %al
-; I386-NOCMOV-NEXT:    fxch %st(1)
-; I386-NOCMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fstps (%esp)
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; I386-NOCMOV-NEXT:    movl (%esp), %edx
+; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-NOCMOV-NEXT:    movb %al, %ah
 ; I386-NOCMOV-NEXT:    movzbl %ah, %edi
 ; I386-NOCMOV-NEXT:    negl %edi
@@ -505,9 +440,9 @@ define float @test_ctselect_f32_bundled(i1 %cond, float %a, float %b) nounwind {
 ; I386-NOCMOV-NEXT:    notl %edi
 ; I386-NOCMOV-NEXT:    andl %ecx, %edi
 ; I386-NOCMOV-NEXT:    orl %edi, %esi
-; I386-NOCMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    addl $12, %esp
+; I386-NOCMOV-NEXT:    movl %esi, (%esp)
+; I386-NOCMOV-NEXT:    flds (%esp)
+; I386-NOCMOV-NEXT:    addl $4, %esp
 ; I386-NOCMOV-NEXT:    popl %esi
 ; I386-NOCMOV-NEXT:    popl %edi
 ; I386-NOCMOV-NEXT:    retl
@@ -516,16 +451,11 @@ define float @test_ctselect_f32_bundled(i1 %cond, float %a, float %b) nounwind {
 ; I386-CMOV:       # %bb.0:
 ; I386-CMOV-NEXT:    pushl %edi
 ; I386-CMOV-NEXT:    pushl %esi
-; I386-CMOV-NEXT:    subl $12, %esp
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; I386-CMOV-NEXT:    pushl %eax
 ; I386-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    sete %al
-; I386-CMOV-NEXT:    fxch %st(1)
-; I386-CMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fstps (%esp)
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; I386-CMOV-NEXT:    movl (%esp), %edx
+; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-CMOV-NEXT:    movb %al, %ah
 ; I386-CMOV-NEXT:    movzbl %ah, %edi
 ; I386-CMOV-NEXT:    negl %edi
@@ -534,9 +464,9 @@ define float @test_ctselect_f32_bundled(i1 %cond, float %a, float %b) nounwind {
 ; I386-CMOV-NEXT:    notl %edi
 ; I386-CMOV-NEXT:    andl %ecx, %edi
 ; I386-CMOV-NEXT:    orl %edi, %esi
-; I386-CMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    addl $12, %esp
+; I386-CMOV-NEXT:    movl %esi, (%esp)
+; I386-CMOV-NEXT:    flds (%esp)
+; I386-CMOV-NEXT:    addl $4, %esp
 ; I386-CMOV-NEXT:    popl %esi
 ; I386-CMOV-NEXT:    popl %edi
 ; I386-CMOV-NEXT:    retl
@@ -615,14 +545,9 @@ define x86_fp80 @test_ctselect_f80_alignment(i1 %cond, x86_fp80 %a, x86_fp80 %b)
 ; I386-NOCMOV:       # %bb.0:
 ; I386-NOCMOV-NEXT:    pushl %edi
 ; I386-NOCMOV-NEXT:    pushl %esi
-; I386-NOCMOV-NEXT:    subl $36, %esp
-; I386-NOCMOV-NEXT:    fldt {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fldt {{[0-9]+}}(%esp)
+; I386-NOCMOV-NEXT:    subl $12, %esp
 ; I386-NOCMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    sete %al
-; I386-NOCMOV-NEXT:    fxch %st(1)
-; I386-NOCMOV-NEXT:    fstpt {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fstpt {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-NOCMOV-NEXT:    movb %al, %ah
@@ -657,7 +582,7 @@ define x86_fp80 @test_ctselect_f80_alignment(i1 %cond, x86_fp80 %a, x86_fp80 %b)
 ; I386-NOCMOV-NEXT:    orl %edi, %esi
 ; I386-NOCMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    fldt (%esp)
-; I386-NOCMOV-NEXT:    addl $36, %esp
+; I386-NOCMOV-NEXT:    addl $12, %esp
 ; I386-NOCMOV-NEXT:    popl %esi
 ; I386-NOCMOV-NEXT:    popl %edi
 ; I386-NOCMOV-NEXT:    retl
@@ -666,14 +591,9 @@ define x86_fp80 @test_ctselect_f80_alignment(i1 %cond, x86_fp80 %a, x86_fp80 %b)
 ; I386-CMOV:       # %bb.0:
 ; I386-CMOV-NEXT:    pushl %edi
 ; I386-CMOV-NEXT:    pushl %esi
-; I386-CMOV-NEXT:    subl $36, %esp
-; I386-CMOV-NEXT:    fldt {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fldt {{[0-9]+}}(%esp)
+; I386-CMOV-NEXT:    subl $12, %esp
 ; I386-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    sete %al
-; I386-CMOV-NEXT:    fxch %st(1)
-; I386-CMOV-NEXT:    fstpt {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fstpt {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-CMOV-NEXT:    movb %al, %ah
@@ -708,7 +628,7 @@ define x86_fp80 @test_ctselect_f80_alignment(i1 %cond, x86_fp80 %a, x86_fp80 %b)
 ; I386-CMOV-NEXT:    orl %edi, %esi
 ; I386-CMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    fldt (%esp)
-; I386-CMOV-NEXT:    addl $36, %esp
+; I386-CMOV-NEXT:    addl $12, %esp
 ; I386-CMOV-NEXT:    popl %esi
 ; I386-CMOV-NEXT:    popl %edi
 ; I386-CMOV-NEXT:    retl
@@ -722,15 +642,9 @@ define float @test_ctselect_f32_multiple(i1 %cond1, i1 %cond2, float %a, float %
 ; I386-NOCMOV:       # %bb.0:
 ; I386-NOCMOV-NEXT:    pushl %edi
 ; I386-NOCMOV-NEXT:    pushl %esi
-; I386-NOCMOV-NEXT:    subl $24, %esp
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; I386-NOCMOV-NEXT:    subl $8, %esp
 ; I386-NOCMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    sete %al
-; I386-NOCMOV-NEXT:    fxch %st(1)
-; I386-NOCMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fstps {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-NOCMOV-NEXT:    movb %al, %ah
@@ -742,13 +656,10 @@ define float @test_ctselect_f32_multiple(i1 %cond1, i1 %cond2, float %a, float %
 ; I386-NOCMOV-NEXT:    andl %ecx, %edi
 ; I386-NOCMOV-NEXT:    orl %edi, %esi
 ; I386-NOCMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-NOCMOV-NEXT:    sete %al
-; I386-NOCMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    fstps (%esp)
 ; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; I386-NOCMOV-NEXT:    movl (%esp), %edx
+; I386-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-NOCMOV-NEXT:    movb %al, %ah
 ; I386-NOCMOV-NEXT:    movzbl %ah, %edi
 ; I386-NOCMOV-NEXT:    negl %edi
@@ -757,9 +668,9 @@ define float @test_ctselect_f32_multiple(i1 %cond1, i1 %cond2, float %a, float %
 ; I386-NOCMOV-NEXT:    notl %edi
 ; I386-NOCMOV-NEXT:    andl %ecx, %edi
 ; I386-NOCMOV-NEXT:    orl %edi, %esi
-; I386-NOCMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-NOCMOV-NEXT:    addl $24, %esp
+; I386-NOCMOV-NEXT:    movl %esi, (%esp)
+; I386-NOCMOV-NEXT:    flds (%esp)
+; I386-NOCMOV-NEXT:    addl $8, %esp
 ; I386-NOCMOV-NEXT:    popl %esi
 ; I386-NOCMOV-NEXT:    popl %edi
 ; I386-NOCMOV-NEXT:    retl
@@ -768,15 +679,9 @@ define float @test_ctselect_f32_multiple(i1 %cond1, i1 %cond2, float %a, float %
 ; I386-CMOV:       # %bb.0:
 ; I386-CMOV-NEXT:    pushl %edi
 ; I386-CMOV-NEXT:    pushl %esi
-; I386-CMOV-NEXT:    subl $24, %esp
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; I386-CMOV-NEXT:    subl $8, %esp
 ; I386-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    sete %al
-; I386-CMOV-NEXT:    fxch %st(1)
-; I386-CMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fstps {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-CMOV-NEXT:    movb %al, %ah
@@ -788,13 +693,10 @@ define float @test_ctselect_f32_multiple(i1 %cond1, i1 %cond2, float %a, float %
 ; I386-CMOV-NEXT:    andl %ecx, %edi
 ; I386-CMOV-NEXT:    orl %edi, %esi
 ; I386-CMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; I386-CMOV-NEXT:    sete %al
-; I386-CMOV-NEXT:    fstps {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    fstps (%esp)
 ; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
-; I386-CMOV-NEXT:    movl (%esp), %edx
+; I386-CMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; I386-CMOV-NEXT:    movb %al, %ah
 ; I386-CMOV-NEXT:    movzbl %ah, %edi
 ; I386-CMOV-NEXT:    negl %edi
@@ -803,9 +705,9 @@ define float @test_ctselect_f32_multiple(i1 %cond1, i1 %cond2, float %a, float %
 ; I386-CMOV-NEXT:    notl %edi
 ; I386-CMOV-NEXT:    andl %ecx, %edi
 ; I386-CMOV-NEXT:    orl %edi, %esi
-; I386-CMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; I386-CMOV-NEXT:    addl $24, %esp
+; I386-CMOV-NEXT:    movl %esi, (%esp)
+; I386-CMOV-NEXT:    flds (%esp)
+; I386-CMOV-NEXT:    addl $8, %esp
 ; I386-CMOV-NEXT:    popl %esi
 ; I386-CMOV-NEXT:    popl %edi
 ; I386-CMOV-NEXT:    retl

--- a/llvm/test/CodeGen/X86/ctselect.ll
+++ b/llvm/test/CodeGen/X86/ctselect.ll
@@ -24,9 +24,6 @@ define i8 @test_ctselect_i8(i1 %cond, i8 %a, i8 %b) {
 ;
 ; X32-NOCMOV-LABEL: test_ctselect_i8:
 ; X32-NOCMOV:       # %bb.0:
-; X32-NOCMOV-NEXT:    pushl %esi
-; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 8
-; X32-NOCMOV-NEXT:    .cfi_offset %esi, -8
 ; X32-NOCMOV-NEXT:    movzbl {{[0-9]+}}(%esp), %ecx
 ; X32-NOCMOV-NEXT:    movzbl {{[0-9]+}}(%esp), %edx
 ; X32-NOCMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
@@ -38,8 +35,6 @@ define i8 @test_ctselect_i8(i1 %cond, i8 %a, i8 %b) {
 ; X32-NOCMOV-NEXT:    notb %ch
 ; X32-NOCMOV-NEXT:    andb %cl, %ch
 ; X32-NOCMOV-NEXT:    orb %ch, %al
-; X32-NOCMOV-NEXT:    popl %esi
-; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 4
 ; X32-NOCMOV-NEXT:    retl
   %result = call i8 @llvm.ct.select.i8(i1 %cond, i8 %a, i8 %b)
   ret i8 %result
@@ -74,13 +69,13 @@ define i16 @test_ctselect_i16(i1 %cond, i16 %a, i16 %b) {
 ; X32-NOCMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
 ; X32-NOCMOV-NEXT:    sete %bl
 ; X32-NOCMOV-NEXT:    movb %bl, %bh
-; X32-NOCMOV-NEXT:    movzbw %bh, %esi
-; X32-NOCMOV-NEXT:    negw %esi
+; X32-NOCMOV-NEXT:    movzbw %bh, %si
+; X32-NOCMOV-NEXT:    negw %si
 ; X32-NOCMOV-NEXT:    movw %dx, %ax
-; X32-NOCMOV-NEXT:    andw %esi, %ax
-; X32-NOCMOV-NEXT:    notw %esi
-; X32-NOCMOV-NEXT:    andw %cx, %esi
-; X32-NOCMOV-NEXT:    orw %esi, %ax
+; X32-NOCMOV-NEXT:    andw %si, %ax
+; X32-NOCMOV-NEXT:    notw %si
+; X32-NOCMOV-NEXT:    andw %cx, %si
+; X32-NOCMOV-NEXT:    orw %si, %ax
 ; X32-NOCMOV-NEXT:    popl %esi
 ; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 8
 ; X32-NOCMOV-NEXT:    popl %ebx
@@ -212,28 +207,66 @@ define float @test_ctselect_f32(i1 %cond, float %a, float %b) {
 ;
 ; X32-LABEL: test_ctselect_f32:
 ; X32:       # %bb.0:
-; X32-NEXT:    flds {{[0-9]+}}(%esp)
-; X32-NEXT:    flds {{[0-9]+}}(%esp)
+; X32-NEXT:    pushl %edi
+; X32-NEXT:    .cfi_def_cfa_offset 8
+; X32-NEXT:    pushl %esi
+; X32-NEXT:    .cfi_def_cfa_offset 12
+; X32-NEXT:    pushl %eax
+; X32-NEXT:    .cfi_def_cfa_offset 16
+; X32-NEXT:    .cfi_offset %esi, -12
+; X32-NEXT:    .cfi_offset %edi, -8
 ; X32-NEXT:    testb $1, {{[0-9]+}}(%esp)
-; X32-NEXT:    jne .LBB4_2
-; X32-NEXT:  # %bb.1:
-; X32-NEXT:    fstp %st(1)
-; X32-NEXT:    fldz
-; X32-NEXT:  .LBB4_2:
-; X32-NEXT:    fstp %st(0)
+; X32-NEXT:    sete %al
+; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X32-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X32-NEXT:    movb %al, %ah
+; X32-NEXT:    movzbl %ah, %edi
+; X32-NEXT:    negl %edi
+; X32-NEXT:    movl %edx, %esi
+; X32-NEXT:    andl %edi, %esi
+; X32-NEXT:    notl %edi
+; X32-NEXT:    andl %ecx, %edi
+; X32-NEXT:    orl %edi, %esi
+; X32-NEXT:    movl %esi, (%esp)
+; X32-NEXT:    flds (%esp)
+; X32-NEXT:    addl $4, %esp
+; X32-NEXT:    .cfi_def_cfa_offset 12
+; X32-NEXT:    popl %esi
+; X32-NEXT:    .cfi_def_cfa_offset 8
+; X32-NEXT:    popl %edi
+; X32-NEXT:    .cfi_def_cfa_offset 4
 ; X32-NEXT:    retl
 ;
 ; X32-NOCMOV-LABEL: test_ctselect_f32:
 ; X32-NOCMOV:       # %bb.0:
-; X32-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; X32-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; X32-NOCMOV-NEXT:    pushl %edi
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 8
+; X32-NOCMOV-NEXT:    pushl %esi
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 12
+; X32-NOCMOV-NEXT:    pushl %eax
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 16
+; X32-NOCMOV-NEXT:    .cfi_offset %esi, -12
+; X32-NOCMOV-NEXT:    .cfi_offset %edi, -8
 ; X32-NOCMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
-; X32-NOCMOV-NEXT:    jne .LBB4_2
-; X32-NOCMOV-NEXT:  # %bb.1:
-; X32-NOCMOV-NEXT:    fstp %st(1)
-; X32-NOCMOV-NEXT:    fldz
-; X32-NOCMOV-NEXT:  .LBB4_2:
-; X32-NOCMOV-NEXT:    fstp %st(0)
+; X32-NOCMOV-NEXT:    sete %al
+; X32-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X32-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X32-NOCMOV-NEXT:    movb %al, %ah
+; X32-NOCMOV-NEXT:    movzbl %ah, %edi
+; X32-NOCMOV-NEXT:    negl %edi
+; X32-NOCMOV-NEXT:    movl %edx, %esi
+; X32-NOCMOV-NEXT:    andl %edi, %esi
+; X32-NOCMOV-NEXT:    notl %edi
+; X32-NOCMOV-NEXT:    andl %ecx, %edi
+; X32-NOCMOV-NEXT:    orl %edi, %esi
+; X32-NOCMOV-NEXT:    movl %esi, (%esp)
+; X32-NOCMOV-NEXT:    flds (%esp)
+; X32-NOCMOV-NEXT:    addl $4, %esp
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 12
+; X32-NOCMOV-NEXT:    popl %esi
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 8
+; X32-NOCMOV-NEXT:    popl %edi
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 4
 ; X32-NOCMOV-NEXT:    retl
   %result = call float @llvm.ct.select.f32(i1 %cond, float %a, float %b)
   ret float %result
@@ -251,28 +284,88 @@ define double @test_ctselect_f64(i1 %cond, double %a, double %b) {
 ;
 ; X32-LABEL: test_ctselect_f64:
 ; X32:       # %bb.0:
-; X32-NEXT:    fldl {{[0-9]+}}(%esp)
-; X32-NEXT:    fldl {{[0-9]+}}(%esp)
+; X32-NEXT:    pushl %edi
+; X32-NEXT:    .cfi_def_cfa_offset 8
+; X32-NEXT:    pushl %esi
+; X32-NEXT:    .cfi_def_cfa_offset 12
+; X32-NEXT:    subl $8, %esp
+; X32-NEXT:    .cfi_def_cfa_offset 20
+; X32-NEXT:    .cfi_offset %esi, -12
+; X32-NEXT:    .cfi_offset %edi, -8
 ; X32-NEXT:    testb $1, {{[0-9]+}}(%esp)
-; X32-NEXT:    jne .LBB5_2
-; X32-NEXT:  # %bb.1:
-; X32-NEXT:    fstp %st(1)
-; X32-NEXT:    fldz
-; X32-NEXT:  .LBB5_2:
-; X32-NEXT:    fstp %st(0)
+; X32-NEXT:    sete %al
+; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X32-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X32-NEXT:    movb %al, %ah
+; X32-NEXT:    movzbl %ah, %edi
+; X32-NEXT:    negl %edi
+; X32-NEXT:    movl %edx, %esi
+; X32-NEXT:    andl %edi, %esi
+; X32-NEXT:    notl %edi
+; X32-NEXT:    andl %ecx, %edi
+; X32-NEXT:    orl %edi, %esi
+; X32-NEXT:    movl %esi, (%esp)
+; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X32-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X32-NEXT:    movb %al, %ah
+; X32-NEXT:    movzbl %ah, %edi
+; X32-NEXT:    negl %edi
+; X32-NEXT:    movl %edx, %esi
+; X32-NEXT:    andl %edi, %esi
+; X32-NEXT:    notl %edi
+; X32-NEXT:    andl %ecx, %edi
+; X32-NEXT:    orl %edi, %esi
+; X32-NEXT:    movl %esi, {{[0-9]+}}(%esp)
+; X32-NEXT:    fldl (%esp)
+; X32-NEXT:    addl $8, %esp
+; X32-NEXT:    .cfi_def_cfa_offset 12
+; X32-NEXT:    popl %esi
+; X32-NEXT:    .cfi_def_cfa_offset 8
+; X32-NEXT:    popl %edi
+; X32-NEXT:    .cfi_def_cfa_offset 4
 ; X32-NEXT:    retl
 ;
 ; X32-NOCMOV-LABEL: test_ctselect_f64:
 ; X32-NOCMOV:       # %bb.0:
-; X32-NOCMOV-NEXT:    fldl {{[0-9]+}}(%esp)
-; X32-NOCMOV-NEXT:    fldl {{[0-9]+}}(%esp)
+; X32-NOCMOV-NEXT:    pushl %edi
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 8
+; X32-NOCMOV-NEXT:    pushl %esi
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 12
+; X32-NOCMOV-NEXT:    subl $8, %esp
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 20
+; X32-NOCMOV-NEXT:    .cfi_offset %esi, -12
+; X32-NOCMOV-NEXT:    .cfi_offset %edi, -8
 ; X32-NOCMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
-; X32-NOCMOV-NEXT:    jne .LBB5_2
-; X32-NOCMOV-NEXT:  # %bb.1:
-; X32-NOCMOV-NEXT:    fstp %st(1)
-; X32-NOCMOV-NEXT:    fldz
-; X32-NOCMOV-NEXT:  .LBB5_2:
-; X32-NOCMOV-NEXT:    fstp %st(0)
+; X32-NOCMOV-NEXT:    sete %al
+; X32-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X32-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X32-NOCMOV-NEXT:    movb %al, %ah
+; X32-NOCMOV-NEXT:    movzbl %ah, %edi
+; X32-NOCMOV-NEXT:    negl %edi
+; X32-NOCMOV-NEXT:    movl %edx, %esi
+; X32-NOCMOV-NEXT:    andl %edi, %esi
+; X32-NOCMOV-NEXT:    notl %edi
+; X32-NOCMOV-NEXT:    andl %ecx, %edi
+; X32-NOCMOV-NEXT:    orl %edi, %esi
+; X32-NOCMOV-NEXT:    movl %esi, (%esp)
+; X32-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X32-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X32-NOCMOV-NEXT:    movb %al, %ah
+; X32-NOCMOV-NEXT:    movzbl %ah, %edi
+; X32-NOCMOV-NEXT:    negl %edi
+; X32-NOCMOV-NEXT:    movl %edx, %esi
+; X32-NOCMOV-NEXT:    andl %edi, %esi
+; X32-NOCMOV-NEXT:    notl %edi
+; X32-NOCMOV-NEXT:    andl %ecx, %edi
+; X32-NOCMOV-NEXT:    orl %edi, %esi
+; X32-NOCMOV-NEXT:    movl %esi, {{[0-9]+}}(%esp)
+; X32-NOCMOV-NEXT:    fldl (%esp)
+; X32-NOCMOV-NEXT:    addl $8, %esp
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 12
+; X32-NOCMOV-NEXT:    popl %esi
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 8
+; X32-NOCMOV-NEXT:    popl %edi
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 4
 ; X32-NOCMOV-NEXT:    retl
   %result = call double @llvm.ct.select.f64(i1 %cond, double %a, double %b)
   ret double %result
@@ -645,8 +738,14 @@ define float @test_ctselect_fcmp_oeq(float %x, float %y, float %a, float %b) {
 ;
 ; X32-LABEL: test_ctselect_fcmp_oeq:
 ; X32:       # %bb.0:
-; X32-NEXT:    flds {{[0-9]+}}(%esp)
-; X32-NEXT:    flds {{[0-9]+}}(%esp)
+; X32-NEXT:    pushl %edi
+; X32-NEXT:    .cfi_def_cfa_offset 8
+; X32-NEXT:    pushl %esi
+; X32-NEXT:    .cfi_def_cfa_offset 12
+; X32-NEXT:    pushl %eax
+; X32-NEXT:    .cfi_def_cfa_offset 16
+; X32-NEXT:    .cfi_offset %esi, -12
+; X32-NEXT:    .cfi_offset %edi, -8
 ; X32-NEXT:    flds {{[0-9]+}}(%esp)
 ; X32-NEXT:    flds {{[0-9]+}}(%esp)
 ; X32-NEXT:    fucompi %st(1), %st
@@ -654,18 +753,37 @@ define float @test_ctselect_fcmp_oeq(float %x, float %y, float %a, float %b) {
 ; X32-NEXT:    setnp %al
 ; X32-NEXT:    sete %cl
 ; X32-NEXT:    testb %al, %cl
-; X32-NEXT:    jne .LBB13_2
-; X32-NEXT:  # %bb.1:
-; X32-NEXT:    fstp %st(1)
-; X32-NEXT:    fldz
-; X32-NEXT:  .LBB13_2:
-; X32-NEXT:    fstp %st(0)
+; X32-NEXT:    sete %al
+; X32-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X32-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X32-NEXT:    movb %al, %ah
+; X32-NEXT:    movzbl %ah, %edi
+; X32-NEXT:    negl %edi
+; X32-NEXT:    movl %edx, %esi
+; X32-NEXT:    andl %edi, %esi
+; X32-NEXT:    notl %edi
+; X32-NEXT:    andl %ecx, %edi
+; X32-NEXT:    orl %edi, %esi
+; X32-NEXT:    movl %esi, (%esp)
+; X32-NEXT:    flds (%esp)
+; X32-NEXT:    addl $4, %esp
+; X32-NEXT:    .cfi_def_cfa_offset 12
+; X32-NEXT:    popl %esi
+; X32-NEXT:    .cfi_def_cfa_offset 8
+; X32-NEXT:    popl %edi
+; X32-NEXT:    .cfi_def_cfa_offset 4
 ; X32-NEXT:    retl
 ;
 ; X32-NOCMOV-LABEL: test_ctselect_fcmp_oeq:
 ; X32-NOCMOV:       # %bb.0:
-; X32-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
-; X32-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
+; X32-NOCMOV-NEXT:    pushl %edi
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 8
+; X32-NOCMOV-NEXT:    pushl %esi
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 12
+; X32-NOCMOV-NEXT:    pushl %eax
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 16
+; X32-NOCMOV-NEXT:    .cfi_offset %esi, -12
+; X32-NOCMOV-NEXT:    .cfi_offset %edi, -8
 ; X32-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
 ; X32-NOCMOV-NEXT:    flds {{[0-9]+}}(%esp)
 ; X32-NOCMOV-NEXT:    fucompp
@@ -675,12 +793,25 @@ define float @test_ctselect_fcmp_oeq(float %x, float %y, float %a, float %b) {
 ; X32-NOCMOV-NEXT:    setnp %al
 ; X32-NOCMOV-NEXT:    sete %cl
 ; X32-NOCMOV-NEXT:    testb %al, %cl
-; X32-NOCMOV-NEXT:    jne .LBB13_2
-; X32-NOCMOV-NEXT:  # %bb.1:
-; X32-NOCMOV-NEXT:    fstp %st(1)
-; X32-NOCMOV-NEXT:    fldz
-; X32-NOCMOV-NEXT:  .LBB13_2:
-; X32-NOCMOV-NEXT:    fstp %st(0)
+; X32-NOCMOV-NEXT:    sete %al
+; X32-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X32-NOCMOV-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X32-NOCMOV-NEXT:    movb %al, %ah
+; X32-NOCMOV-NEXT:    movzbl %ah, %edi
+; X32-NOCMOV-NEXT:    negl %edi
+; X32-NOCMOV-NEXT:    movl %edx, %esi
+; X32-NOCMOV-NEXT:    andl %edi, %esi
+; X32-NOCMOV-NEXT:    notl %edi
+; X32-NOCMOV-NEXT:    andl %ecx, %edi
+; X32-NOCMOV-NEXT:    orl %edi, %esi
+; X32-NOCMOV-NEXT:    movl %esi, (%esp)
+; X32-NOCMOV-NEXT:    flds (%esp)
+; X32-NOCMOV-NEXT:    addl $4, %esp
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 12
+; X32-NOCMOV-NEXT:    popl %esi
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 8
+; X32-NOCMOV-NEXT:    popl %edi
+; X32-NOCMOV-NEXT:    .cfi_def_cfa_offset 4
 ; X32-NOCMOV-NEXT:    retl
   %cond = fcmp oeq float %x, %y
   %result = call float @llvm.ct.select.f32(i1 %cond, float %a, float %b)


### PR DESCRIPTION
Typical sequence was:
1. Load fp from mem -> fp reg
2. Store fp -> stack
3. Load int from stack

New sequence is instead:
1. Load from stack (as int)

This improves codegen for:
- Global floating point variables
- Global floating point constants
- Stack based floating point variables