### PR TITLE
[CT] Updated ARM32 ctselect tests for LLVM 21

### DIFF
--- a/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
+++ b/llvm/lib/Target/ARM/ARMBaseInstrInfo.cpp
@@ -1638,16 +1638,20 @@ bool ARMBaseInstrInfo::expandCtSelectThumb(MachineInstr &MI) const {
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
 
   // Instead of using RSB, we can use LSL and ASR to get the mask. This is to avoid the flag modification caused by RSB.
+  // tLSLri: (outs tGPR:$Rd, s_cc_out:$s), (ins tGPR:$Rm, imm0_31:$imm5, pred:$p)
   BuildMI(*MBB, MI, DL, get(ARM::tLSLri), MaskReg)
-    .addReg(MaskReg)
-    .addImm(ShiftAmount)
-    .add(predOps(ARMCC::AL))
+    .addReg(ARM::CPSR, RegState::Define | RegState::Dead)  // s_cc_out:$s
+    .addReg(MaskReg)  // $Rm
+    .addImm(ShiftAmount)  // imm0_31:$imm5
+    .add(predOps(ARMCC::AL))  // pred:$p
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
 
+  // tASRri: (outs tGPR:$Rd, s_cc_out:$s), (ins tGPR:$Rm, imm_sr:$imm5, pred:$p)
   BuildMI(*MBB, MI, DL, get(ARM::tASRri), MaskReg)
-    .addReg(MaskReg)
-    .addImm(ShiftAmount)
-    .add(predOps(ARMCC::AL))
+    .addReg(ARM::CPSR, RegState::Define | RegState::Dead)  // s_cc_out:$s
+    .addReg(MaskReg)  // $Rm
+    .addImm(ShiftAmount)  // imm_sr:$imm5
+    .add(predOps(ARMCC::AL))  // pred:$p
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
 
   // 2. xor_diff = src1 ^ src2
@@ -1656,24 +1660,30 @@ bool ARMBaseInstrInfo::expandCtSelectThumb(MachineInstr &MI) const {
     .add(predOps(ARMCC::AL))
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
 
+  // tEOR has tied operands: (outs tGPR:$Rdn, s_cc_out:$s), (ins tGPR:$Rn, pred:$p) with constraint "$Rn = $Rdn"
   BuildMI(*MBB, MI, DL, get(ARM::tEOR), DestReg)
-    .addReg(DestReg)
-    .addReg(Src2Reg)
-    .add(predOps(ARMCC::AL))
+    .addReg(ARM::CPSR, RegState::Define | RegState::Dead)  // s_cc_out:$s
+    .addReg(DestReg)  // tied input $Rn
+    .addReg(Src2Reg)  // $Rm
+    .add(predOps(ARMCC::AL))  // pred:$p
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
 
   // 3. masked_xor = xor_diff & mask
+  // tAND has tied operands: (outs tGPR:$Rdn, s_cc_out:$s), (ins tGPR:$Rn, pred:$p) with constraint "$Rn = $Rdn"
   BuildMI(*MBB, MI, DL, get(ARM::tAND), DestReg)
-    .addReg(DestReg)
-    .addReg(MaskReg, RegState::Kill)
-    .add(predOps(ARMCC::AL))
+    .addReg(ARM::CPSR, RegState::Define | RegState::Dead)  // s_cc_out:$s
+    .addReg(DestReg)  // tied input $Rn
+    .addReg(MaskReg, RegState::Kill)  // $Rm
+    .add(predOps(ARMCC::AL))  // pred:$p
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
 
   // 4. result = src2 ^ masked_xor
+  // tEOR has tied operands: (outs tGPR:$Rdn, s_cc_out:$s), (ins tGPR:$Rn, pred:$p) with constraint "$Rn = $Rdn"
   auto LastMI = BuildMI(*MBB, MI, DL, get(ARM::tEOR), DestReg)
-    .addReg(DestReg)
-    .addReg(Src2Reg)
-    .add(predOps(ARMCC::AL))
+    .addReg(ARM::CPSR, RegState::Define | RegState::Dead)  // s_cc_out:$s
+    .addReg(DestReg)  // tied input $Rn
+    .addReg(Src2Reg)  // $Rm
+    .add(predOps(ARMCC::AL))  // pred:$p
     .setMIFlag(MachineInstr::MIFlag::NoMerge);
 
   // Add instruction bundling

--- a/llvm/test/CodeGen/ARM/ctselect-half.ll
+++ b/llvm/test/CodeGen/ARM/ctselect-half.ll
@@ -129,19 +129,19 @@ define <4 x half> @ct_v4f16(i1 %cond, <4 x half> %a, <4 x half> %b) {
 ; CT-NEXT:    push {r4, r5, r6, lr}
 ; CT-NEXT:    ldrh r1, [sp, #20]
 ; CT-NEXT:    pkhbt r2, r2, r3, lsl #16
-; CT-NEXT:    ldrh r4, [sp, #16]
-; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    ldrh r12, [sp, #36]
+; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    ldrh lr, [sp, #28]
-; CT-NEXT:    orr r1, r4, r1, lsl #16
 ; CT-NEXT:    ldrh r6, [sp, #24]
+; CT-NEXT:    ldrh r4, [sp, #16]
 ; CT-NEXT:    ldrh r5, [sp, #32]
-; CT-NEXT:    vmov d17, r2, r1
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    orr r6, r6, lr, lsl #16
+; CT-NEXT:    orr r1, r4, r1, lsl #16
 ; CT-NEXT:    orr r3, r5, r12, lsl #16
-; CT-NEXT:    vdup.32 d19, r1
+; CT-NEXT:    vmov d17, r2, r1
 ; CT-NEXT:    vmov d16, r6, r3
+; CT-NEXT:    rsb r1, r0, #0
+; CT-NEXT:    vdup.32 d19, r1
 ; CT-NEXT:    vand d18, d17, d19
 ; CT-NEXT:    vbic d19, d16, d19
 ; CT-NEXT:    vorr d18, d18, d19
@@ -157,19 +157,19 @@ define <4 x half> @ct_v4f16(i1 %cond, <4 x half> %a, <4 x half> %b) {
 ; BFLOAT-F16-NATIVE-NEXT:    push {r4, r5, r6, lr}
 ; BFLOAT-F16-NATIVE-NEXT:    ldrh r1, [sp, #20]
 ; BFLOAT-F16-NATIVE-NEXT:    pkhbt r2, r2, r3, lsl #16
-; BFLOAT-F16-NATIVE-NEXT:    ldrh r4, [sp, #16]
-; BFLOAT-F16-NATIVE-NEXT:    and r0, r0, #1
 ; BFLOAT-F16-NATIVE-NEXT:    ldrh r12, [sp, #36]
+; BFLOAT-F16-NATIVE-NEXT:    and r0, r0, #1
 ; BFLOAT-F16-NATIVE-NEXT:    ldrh lr, [sp, #28]
-; BFLOAT-F16-NATIVE-NEXT:    orr r1, r4, r1, lsl #16
 ; BFLOAT-F16-NATIVE-NEXT:    ldrh r6, [sp, #24]
+; BFLOAT-F16-NATIVE-NEXT:    ldrh r4, [sp, #16]
 ; BFLOAT-F16-NATIVE-NEXT:    ldrh r5, [sp, #32]
-; BFLOAT-F16-NATIVE-NEXT:    vmov d17, r2, r1
-; BFLOAT-F16-NATIVE-NEXT:    rsb r1, r0, #0
 ; BFLOAT-F16-NATIVE-NEXT:    orr r6, r6, lr, lsl #16
+; BFLOAT-F16-NATIVE-NEXT:    orr r1, r4, r1, lsl #16
 ; BFLOAT-F16-NATIVE-NEXT:    orr r3, r5, r12, lsl #16
-; BFLOAT-F16-NATIVE-NEXT:    vdup.32 d19, r1
+; BFLOAT-F16-NATIVE-NEXT:    vmov d17, r2, r1
 ; BFLOAT-F16-NATIVE-NEXT:    vmov d16, r6, r3
+; BFLOAT-F16-NATIVE-NEXT:    rsb r1, r0, #0
+; BFLOAT-F16-NATIVE-NEXT:    vdup.32 d19, r1
 ; BFLOAT-F16-NATIVE-NEXT:    vand d18, d17, d19
 ; BFLOAT-F16-NATIVE-NEXT:    vbic d19, d16, d19
 ; BFLOAT-F16-NATIVE-NEXT:    vorr d18, d18, d19
@@ -185,19 +185,19 @@ define <4 x half> @ct_v4f16(i1 %cond, <4 x half> %a, <4 x half> %b) {
 ; F16-NATIVE-NEXT:    push {r4, r5, r6, lr}
 ; F16-NATIVE-NEXT:    ldrh r1, [sp, #20]
 ; F16-NATIVE-NEXT:    pkhbt r2, r2, r3, lsl #16
-; F16-NATIVE-NEXT:    ldrh r4, [sp, #16]
-; F16-NATIVE-NEXT:    and r0, r0, #1
 ; F16-NATIVE-NEXT:    ldrh r12, [sp, #36]
+; F16-NATIVE-NEXT:    and r0, r0, #1
 ; F16-NATIVE-NEXT:    ldrh lr, [sp, #28]
-; F16-NATIVE-NEXT:    orr r1, r4, r1, lsl #16
 ; F16-NATIVE-NEXT:    ldrh r6, [sp, #24]
+; F16-NATIVE-NEXT:    ldrh r4, [sp, #16]
 ; F16-NATIVE-NEXT:    ldrh r5, [sp, #32]
-; F16-NATIVE-NEXT:    vmov d17, r2, r1
-; F16-NATIVE-NEXT:    rsb r1, r0, #0
 ; F16-NATIVE-NEXT:    orr r6, r6, lr, lsl #16
+; F16-NATIVE-NEXT:    orr r1, r4, r1, lsl #16
 ; F16-NATIVE-NEXT:    orr r3, r5, r12, lsl #16
-; F16-NATIVE-NEXT:    vdup.32 d19, r1
+; F16-NATIVE-NEXT:    vmov d17, r2, r1
 ; F16-NATIVE-NEXT:    vmov d16, r6, r3
+; F16-NATIVE-NEXT:    rsb r1, r0, #0
+; F16-NATIVE-NEXT:    vdup.32 d19, r1
 ; F16-NATIVE-NEXT:    vand d18, d17, d19
 ; F16-NATIVE-NEXT:    vbic d19, d16, d19
 ; F16-NATIVE-NEXT:    vorr d18, d18, d19
@@ -259,23 +259,23 @@ define <4 x half> @ct_v4f16(i1 %cond, <4 x half> %a, <4 x half> %b) {
 ; THUMB2-NEXT:    and r12, r0, #1
 ; THUMB2-NEXT:    ldrh.w r1, [sp, #24]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r0, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r1, lr
-; THUMB2-NEXT:    ldrh.w r2, [sp, #28]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldrh.w r2, [sp, #28]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r1, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r2, lr
 ; THUMB2-NEXT:    orr.w r1, r1, lr
 ; THUMB2-NEXT:    ldrh.w r3, [sp, #16]
 ; THUMB2-NEXT:    ldrh.w lr, [sp, #32]
+; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r2, r3, r4
 ; THUMB2-NEXT:    bic.w r4, lr, r4
-; THUMB2-NEXT:    ldrh.w lr, [sp, #36]
 ; THUMB2-NEXT:    orrs r2, r4
+; THUMB2-NEXT:    ldrh.w lr, [sp, #36]
 ; THUMB2-NEXT:    ldrh.w r4, [sp, #20]
+; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r3, r4, r5
 ; THUMB2-NEXT:    bic.w r5, lr, r5
 ; THUMB2-NEXT:    orrs r3, r5
@@ -292,19 +292,19 @@ define <4 x bfloat> @ct_v4bf16(i1 %cond, <4 x bfloat> %a, <4 x bfloat> %b) {
 ; CT-NEXT:    push {r4, r5, r6, lr}
 ; CT-NEXT:    ldrh r1, [sp, #20]
 ; CT-NEXT:    pkhbt r2, r2, r3, lsl #16
-; CT-NEXT:    ldrh r4, [sp, #16]
-; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    ldrh r12, [sp, #36]
+; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    ldrh lr, [sp, #28]
-; CT-NEXT:    orr r1, r4, r1, lsl #16
 ; CT-NEXT:    ldrh r6, [sp, #24]
+; CT-NEXT:    ldrh r4, [sp, #16]
 ; CT-NEXT:    ldrh r5, [sp, #32]
-; CT-NEXT:    vmov d17, r2, r1
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    orr r6, r6, lr, lsl #16
+; CT-NEXT:    orr r1, r4, r1, lsl #16
 ; CT-NEXT:    orr r3, r5, r12, lsl #16
-; CT-NEXT:    vdup.32 d19, r1
+; CT-NEXT:    vmov d17, r2, r1
 ; CT-NEXT:    vmov d16, r6, r3
+; CT-NEXT:    rsb r1, r0, #0
+; CT-NEXT:    vdup.32 d19, r1
 ; CT-NEXT:    vand d18, d17, d19
 ; CT-NEXT:    vbic d19, d16, d19
 ; CT-NEXT:    vorr d18, d18, d19
@@ -316,10 +316,10 @@ define <4 x bfloat> @ct_v4bf16(i1 %cond, <4 x bfloat> %a, <4 x bfloat> %b) {
 ;
 ; BFLOAT-F16-NATIVE-LABEL: ct_v4bf16:
 ; BFLOAT-F16-NATIVE:       @ %bb.0: @ %entry
-; BFLOAT-F16-NATIVE-NEXT:    and r0, r0, #1
 ; BFLOAT-F16-NATIVE-NEXT:    vldr d16, [sp]
-; BFLOAT-F16-NATIVE-NEXT:    rsb r1, r0, #0
 ; BFLOAT-F16-NATIVE-NEXT:    vmov d17, r2, r3
+; BFLOAT-F16-NATIVE-NEXT:    and r0, r0, #1
+; BFLOAT-F16-NATIVE-NEXT:    rsb r1, r0, #0
 ; BFLOAT-F16-NATIVE-NEXT:    vdup.32 d19, r1
 ; BFLOAT-F16-NATIVE-NEXT:    vand d18, d17, d19
 ; BFLOAT-F16-NATIVE-NEXT:    vbic d19, d16, d19
@@ -333,19 +333,19 @@ define <4 x bfloat> @ct_v4bf16(i1 %cond, <4 x bfloat> %a, <4 x bfloat> %b) {
 ; F16-NATIVE-NEXT:    push {r4, r5, r6, lr}
 ; F16-NATIVE-NEXT:    ldrh r1, [sp, #20]
 ; F16-NATIVE-NEXT:    pkhbt r2, r2, r3, lsl #16
-; F16-NATIVE-NEXT:    ldrh r4, [sp, #16]
-; F16-NATIVE-NEXT:    and r0, r0, #1
 ; F16-NATIVE-NEXT:    ldrh r12, [sp, #36]
+; F16-NATIVE-NEXT:    and r0, r0, #1
 ; F16-NATIVE-NEXT:    ldrh lr, [sp, #28]
-; F16-NATIVE-NEXT:    orr r1, r4, r1, lsl #16
 ; F16-NATIVE-NEXT:    ldrh r6, [sp, #24]
+; F16-NATIVE-NEXT:    ldrh r4, [sp, #16]
 ; F16-NATIVE-NEXT:    ldrh r5, [sp, #32]
-; F16-NATIVE-NEXT:    vmov d17, r2, r1
-; F16-NATIVE-NEXT:    rsb r1, r0, #0
 ; F16-NATIVE-NEXT:    orr r6, r6, lr, lsl #16
+; F16-NATIVE-NEXT:    orr r1, r4, r1, lsl #16
 ; F16-NATIVE-NEXT:    orr r3, r5, r12, lsl #16
-; F16-NATIVE-NEXT:    vdup.32 d19, r1
+; F16-NATIVE-NEXT:    vmov d17, r2, r1
 ; F16-NATIVE-NEXT:    vmov d16, r6, r3
+; F16-NATIVE-NEXT:    rsb r1, r0, #0
+; F16-NATIVE-NEXT:    vdup.32 d19, r1
 ; F16-NATIVE-NEXT:    vand d18, d17, d19
 ; F16-NATIVE-NEXT:    vbic d19, d16, d19
 ; F16-NATIVE-NEXT:    vorr d18, d18, d19
@@ -407,23 +407,23 @@ define <4 x bfloat> @ct_v4bf16(i1 %cond, <4 x bfloat> %a, <4 x bfloat> %b) {
 ; THUMB2-NEXT:    and r12, r0, #1
 ; THUMB2-NEXT:    ldrh.w r1, [sp, #24]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r0, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r1, lr
-; THUMB2-NEXT:    ldrh.w r2, [sp, #28]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldrh.w r2, [sp, #28]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r1, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r2, lr
 ; THUMB2-NEXT:    orr.w r1, r1, lr
 ; THUMB2-NEXT:    ldrh.w r3, [sp, #16]
 ; THUMB2-NEXT:    ldrh.w lr, [sp, #32]
+; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r2, r3, r4
 ; THUMB2-NEXT:    bic.w r4, lr, r4
-; THUMB2-NEXT:    ldrh.w lr, [sp, #36]
 ; THUMB2-NEXT:    orrs r2, r4
+; THUMB2-NEXT:    ldrh.w lr, [sp, #36]
 ; THUMB2-NEXT:    ldrh.w r4, [sp, #20]
+; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r3, r4, r5
 ; THUMB2-NEXT:    bic.w r5, lr, r5
 ; THUMB2-NEXT:    orrs r3, r5
@@ -663,49 +663,49 @@ define <8 x half> @ct_v8f16(i1 %cond, <8 x half> %a, <8 x half> %b) {
 ; THUMB2-NEXT:    and.w r4, r1, r5
 ; THUMB2-NEXT:    bic.w r5, r12, r5
 ; THUMB2-NEXT:    orrs r4, r5
+; THUMB2-NEXT:    strh r4, [r0, #14]
 ; THUMB2-NEXT:    ldrh.w r12, [sp, #64]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #32]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #14]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrh.w r12, [sp, #60]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strh r4, [r0, #12]
+; THUMB2-NEXT:    ldrh.w r12, [sp, #60]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #28]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #12]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrh.w r12, [sp, #56]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strh r4, [r0, #10]
+; THUMB2-NEXT:    ldrh.w r12, [sp, #56]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #24]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #10]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrh.w r12, [sp, #52]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strh r4, [r0, #8]
+; THUMB2-NEXT:    ldrh.w r12, [sp, #52]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #20]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #8]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrh.w r12, [sp, #48]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strh r4, [r0, #6]
+; THUMB2-NEXT:    ldrh.w r12, [sp, #48]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #16]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #6]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
 ; THUMB2-NEXT:    orrs r4, r1
-; THUMB2-NEXT:    ldrh.w r1, [sp, #44]
 ; THUMB2-NEXT:    strh r4, [r0, #4]
+; THUMB2-NEXT:    ldrh.w r1, [sp, #44]
 ; THUMB2-NEXT:    rsb.w r4, lr, #0
 ; THUMB2-NEXT:    and.w r5, r3, r4
 ; THUMB2-NEXT:    bic.w r4, r1, r4
 ; THUMB2-NEXT:    orrs r5, r4
-; THUMB2-NEXT:    ldrh.w r1, [sp, #40]
 ; THUMB2-NEXT:    strh r5, [r0, #2]
+; THUMB2-NEXT:    ldrh.w r1, [sp, #40]
 ; THUMB2-NEXT:    rsb.w r5, lr, #0
 ; THUMB2-NEXT:    and.w r3, r2, r5
 ; THUMB2-NEXT:    bic.w r5, r1, r5
@@ -763,12 +763,12 @@ define <8 x bfloat> @ct_v8bf16(i1 %cond, <8 x bfloat> %a, <8 x bfloat> %b) {
 ;
 ; BFLOAT-F16-NATIVE-LABEL: ct_v8bf16:
 ; BFLOAT-F16-NATIVE:       @ %bb.0: @ %entry
-; BFLOAT-F16-NATIVE-NEXT:    add r1, sp, #8
-; BFLOAT-F16-NATIVE-NEXT:    and r0, r0, #1
-; BFLOAT-F16-NATIVE-NEXT:    vld1.64 {d18, d19}, [r1]
-; BFLOAT-F16-NATIVE-NEXT:    rsb r1, r0, #0
 ; BFLOAT-F16-NATIVE-NEXT:    vldr d17, [sp]
+; BFLOAT-F16-NATIVE-NEXT:    add r1, sp, #8
 ; BFLOAT-F16-NATIVE-NEXT:    vmov d16, r2, r3
+; BFLOAT-F16-NATIVE-NEXT:    vld1.64 {d18, d19}, [r1]
+; BFLOAT-F16-NATIVE-NEXT:    and r0, r0, #1
+; BFLOAT-F16-NATIVE-NEXT:    rsb r1, r0, #0
 ; BFLOAT-F16-NATIVE-NEXT:    vdup.32 q11, r1
 ; BFLOAT-F16-NATIVE-NEXT:    vand q10, q8, q11
 ; BFLOAT-F16-NATIVE-NEXT:    vbic q11, q9, q11
@@ -920,49 +920,49 @@ define <8 x bfloat> @ct_v8bf16(i1 %cond, <8 x bfloat> %a, <8 x bfloat> %b) {
 ; THUMB2-NEXT:    and.w r4, r1, r5
 ; THUMB2-NEXT:    bic.w r5, r12, r5
 ; THUMB2-NEXT:    orrs r4, r5
+; THUMB2-NEXT:    strh r4, [r0, #14]
 ; THUMB2-NEXT:    ldrh.w r12, [sp, #64]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #32]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #14]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrh.w r12, [sp, #60]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strh r4, [r0, #12]
+; THUMB2-NEXT:    ldrh.w r12, [sp, #60]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #28]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #12]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrh.w r12, [sp, #56]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strh r4, [r0, #10]
+; THUMB2-NEXT:    ldrh.w r12, [sp, #56]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #24]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #10]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrh.w r12, [sp, #52]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strh r4, [r0, #8]
+; THUMB2-NEXT:    ldrh.w r12, [sp, #52]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #20]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #8]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrh.w r12, [sp, #48]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strh r4, [r0, #6]
+; THUMB2-NEXT:    ldrh.w r12, [sp, #48]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #16]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #6]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
 ; THUMB2-NEXT:    orrs r4, r1
-; THUMB2-NEXT:    ldrh.w r1, [sp, #44]
 ; THUMB2-NEXT:    strh r4, [r0, #4]
+; THUMB2-NEXT:    ldrh.w r1, [sp, #44]
 ; THUMB2-NEXT:    rsb.w r4, lr, #0
 ; THUMB2-NEXT:    and.w r5, r3, r4
 ; THUMB2-NEXT:    bic.w r4, r1, r4
 ; THUMB2-NEXT:    orrs r5, r4
-; THUMB2-NEXT:    ldrh.w r1, [sp, #40]
 ; THUMB2-NEXT:    strh r5, [r0, #2]
+; THUMB2-NEXT:    ldrh.w r1, [sp, #40]
 ; THUMB2-NEXT:    rsb.w r5, lr, #0
 ; THUMB2-NEXT:    and.w r3, r2, r5
 ; THUMB2-NEXT:    bic.w r5, r1, r5

--- a/llvm/test/CodeGen/ARM/ctselect-vector.ll
+++ b/llvm/test/CodeGen/ARM/ctselect-vector.ll
@@ -7,10 +7,10 @@
 define <8 x i8> @ct_v8i8(i1 %cond, <8 x i8> %a, <8 x i8> %b) {
 ; CT-LABEL: ct_v8i8:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    vldr d16, [sp]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vmov d17, r2, r3
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 d19, r1
 ; CT-NEXT:    vand d18, d17, d19
 ; CT-NEXT:    vbic d19, d16, d19
@@ -28,49 +28,49 @@ define <8 x i8> @ct_v8i8(i1 %cond, <8 x i8> %a, <8 x i8> %b) {
 ; DEFAULT-NEXT:    and r4, r1, r5
 ; DEFAULT-NEXT:    bic r5, r12, r5
 ; DEFAULT-NEXT:    orr r4, r4, r5
+; DEFAULT-NEXT:    strb r4, [r0, #7]
 ; DEFAULT-NEXT:    ldrb r12, [sp, #64]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #32]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #7]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #60]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #6]
+; DEFAULT-NEXT:    ldrb r12, [sp, #60]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #28]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #6]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #56]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #5]
+; DEFAULT-NEXT:    ldrb r12, [sp, #56]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #24]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #5]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #52]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #4]
+; DEFAULT-NEXT:    ldrb r12, [sp, #52]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #20]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #4]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #48]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #3]
+; DEFAULT-NEXT:    ldrb r12, [sp, #48]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #16]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #3]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
 ; DEFAULT-NEXT:    orr r4, r4, r1
-; DEFAULT-NEXT:    ldrb r1, [sp, #44]
 ; DEFAULT-NEXT:    strb r4, [r0, #2]
+; DEFAULT-NEXT:    ldrb r1, [sp, #44]
 ; DEFAULT-NEXT:    rsb r4, lr, #0
 ; DEFAULT-NEXT:    and r5, r3, r4
 ; DEFAULT-NEXT:    bic r4, r1, r4
 ; DEFAULT-NEXT:    orr r5, r5, r4
-; DEFAULT-NEXT:    ldrb r1, [sp, #40]
 ; DEFAULT-NEXT:    strb r5, [r0, #1]
+; DEFAULT-NEXT:    ldrb r1, [sp, #40]
 ; DEFAULT-NEXT:    rsb r5, lr, #0
 ; DEFAULT-NEXT:    and r3, r2, r5
 ; DEFAULT-NEXT:    bic r5, r1, r5
@@ -178,49 +178,49 @@ define <8 x i8> @ct_v8i8(i1 %cond, <8 x i8> %a, <8 x i8> %b) {
 ; THUMB2-NEXT:    and.w r4, r1, r5
 ; THUMB2-NEXT:    bic.w r5, r12, r5
 ; THUMB2-NEXT:    orrs r4, r5
+; THUMB2-NEXT:    strb r4, [r0, #7]
 ; THUMB2-NEXT:    ldrb.w r12, [sp, #64]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #32]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #7]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #60]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #6]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #60]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #28]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #6]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #56]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #5]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #56]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #24]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #5]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #52]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #4]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #52]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #20]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #4]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #48]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #3]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #48]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #16]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #3]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
 ; THUMB2-NEXT:    orrs r4, r1
-; THUMB2-NEXT:    ldrb.w r1, [sp, #44]
 ; THUMB2-NEXT:    strb r4, [r0, #2]
+; THUMB2-NEXT:    ldrb.w r1, [sp, #44]
 ; THUMB2-NEXT:    rsb.w r4, lr, #0
 ; THUMB2-NEXT:    and.w r5, r3, r4
 ; THUMB2-NEXT:    bic.w r4, r1, r4
 ; THUMB2-NEXT:    orrs r5, r4
-; THUMB2-NEXT:    ldrb.w r1, [sp, #40]
 ; THUMB2-NEXT:    strb r5, [r0, #1]
+; THUMB2-NEXT:    ldrb.w r1, [sp, #40]
 ; THUMB2-NEXT:    rsb.w r5, lr, #0
 ; THUMB2-NEXT:    and.w r3, r2, r5
 ; THUMB2-NEXT:    bic.w r5, r1, r5
@@ -235,10 +235,10 @@ entry:
 define <4 x i16> @ct_v4i16(i1 %cond, <4 x i16> %a, <4 x i16> %b) {
 ; CT-LABEL: ct_v4i16:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    vldr d16, [sp]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vmov d17, r2, r3
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 d19, r1
 ; CT-NEXT:    vand d18, d17, d19
 ; CT-NEXT:    vbic d19, d16, d19
@@ -252,23 +252,23 @@ define <4 x i16> @ct_v4i16(i1 %cond, <4 x i16> %a, <4 x i16> %b) {
 ; DEFAULT-NEXT:    and r12, r0, #1
 ; DEFAULT-NEXT:    ldrh r1, [sp, #24]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
-; DEFAULT-NEXT:    rsb r4, r12, #0
 ; DEFAULT-NEXT:    and r0, r2, lr
 ; DEFAULT-NEXT:    bic lr, r1, lr
-; DEFAULT-NEXT:    ldrh r2, [sp, #28]
 ; DEFAULT-NEXT:    orr r0, r0, lr
+; DEFAULT-NEXT:    ldrh r2, [sp, #28]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
-; DEFAULT-NEXT:    rsb r5, r12, #0
 ; DEFAULT-NEXT:    and r1, r3, lr
 ; DEFAULT-NEXT:    bic lr, r2, lr
 ; DEFAULT-NEXT:    orr r1, r1, lr
 ; DEFAULT-NEXT:    ldrh r3, [sp, #16]
 ; DEFAULT-NEXT:    ldrh lr, [sp, #32]
+; DEFAULT-NEXT:    rsb r4, r12, #0
 ; DEFAULT-NEXT:    and r2, r3, r4
 ; DEFAULT-NEXT:    bic r4, lr, r4
-; DEFAULT-NEXT:    ldrh lr, [sp, #36]
 ; DEFAULT-NEXT:    orr r2, r2, r4
+; DEFAULT-NEXT:    ldrh lr, [sp, #36]
 ; DEFAULT-NEXT:    ldrh r4, [sp, #20]
+; DEFAULT-NEXT:    rsb r5, r12, #0
 ; DEFAULT-NEXT:    and r3, r4, r5
 ; DEFAULT-NEXT:    bic r5, lr, r5
 ; DEFAULT-NEXT:    orr r3, r3, r5
@@ -326,23 +326,23 @@ define <4 x i16> @ct_v4i16(i1 %cond, <4 x i16> %a, <4 x i16> %b) {
 ; THUMB2-NEXT:    and r12, r0, #1
 ; THUMB2-NEXT:    ldrh.w r1, [sp, #24]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r0, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r1, lr
-; THUMB2-NEXT:    ldrh.w r2, [sp, #28]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldrh.w r2, [sp, #28]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r1, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r2, lr
 ; THUMB2-NEXT:    orr.w r1, r1, lr
 ; THUMB2-NEXT:    ldrh.w r3, [sp, #16]
 ; THUMB2-NEXT:    ldrh.w lr, [sp, #32]
+; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r2, r3, r4
 ; THUMB2-NEXT:    bic.w r4, lr, r4
-; THUMB2-NEXT:    ldrh.w lr, [sp, #36]
 ; THUMB2-NEXT:    orrs r2, r4
+; THUMB2-NEXT:    ldrh.w lr, [sp, #36]
 ; THUMB2-NEXT:    ldrh.w r4, [sp, #20]
+; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r3, r4, r5
 ; THUMB2-NEXT:    bic.w r5, lr, r5
 ; THUMB2-NEXT:    orrs r3, r5
@@ -355,10 +355,10 @@ entry:
 define <2 x i32> @ct_v2i32(i1 %cond, <2 x i32> %a, <2 x i32> %b) {
 ; CT-LABEL: ct_v2i32:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    vldr d16, [sp]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vmov d17, r2, r3
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 d19, r1
 ; CT-NEXT:    vand d18, d17, d19
 ; CT-NEXT:    vbic d19, d16, d19
@@ -374,8 +374,8 @@ define <2 x i32> @ct_v2i32(i1 %cond, <2 x i32> %a, <2 x i32> %b) {
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r0, r2, lr
 ; DEFAULT-NEXT:    bic lr, r1, lr
-; DEFAULT-NEXT:    ldr r2, [sp, #12]
 ; DEFAULT-NEXT:    orr r0, r0, lr
+; DEFAULT-NEXT:    ldr r2, [sp, #12]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r1, r3, lr
 ; DEFAULT-NEXT:    bic lr, r2, lr
@@ -415,8 +415,8 @@ define <2 x i32> @ct_v2i32(i1 %cond, <2 x i32> %a, <2 x i32> %b) {
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r0, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r1, lr
-; THUMB2-NEXT:    ldr r2, [sp, #12]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldr r2, [sp, #12]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r1, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r2, lr
@@ -430,10 +430,10 @@ entry:
 define <1 x i64> @ct_v1i64(i1 %cond, <1 x i64> %a, <1 x i64> %b) {
 ; CT-LABEL: ct_v1i64:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    vldr d16, [sp]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vmov d17, r2, r3
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 d19, r1
 ; CT-NEXT:    vand d18, d17, d19
 ; CT-NEXT:    vbic d19, d16, d19
@@ -449,8 +449,8 @@ define <1 x i64> @ct_v1i64(i1 %cond, <1 x i64> %a, <1 x i64> %b) {
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r0, r2, lr
 ; DEFAULT-NEXT:    bic lr, r1, lr
-; DEFAULT-NEXT:    ldr r2, [sp, #12]
 ; DEFAULT-NEXT:    orr r0, r0, lr
+; DEFAULT-NEXT:    ldr r2, [sp, #12]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r1, r3, lr
 ; DEFAULT-NEXT:    bic lr, r2, lr
@@ -490,8 +490,8 @@ define <1 x i64> @ct_v1i64(i1 %cond, <1 x i64> %a, <1 x i64> %b) {
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r0, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r1, lr
-; THUMB2-NEXT:    ldr r2, [sp, #12]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldr r2, [sp, #12]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r1, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r2, lr
@@ -505,10 +505,10 @@ entry:
 define <2 x float> @ct_v2f32(i1 %cond, <2 x float> %a, <2 x float> %b) {
 ; CT-LABEL: ct_v2f32:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    vldr d16, [sp]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vmov d17, r2, r3
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 d19, r1
 ; CT-NEXT:    vand d18, d17, d19
 ; CT-NEXT:    vbic d19, d16, d19
@@ -524,8 +524,8 @@ define <2 x float> @ct_v2f32(i1 %cond, <2 x float> %a, <2 x float> %b) {
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r0, r2, lr
 ; DEFAULT-NEXT:    bic lr, r1, lr
-; DEFAULT-NEXT:    ldr r2, [sp, #12]
 ; DEFAULT-NEXT:    orr r0, r0, lr
+; DEFAULT-NEXT:    ldr r2, [sp, #12]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r1, r3, lr
 ; DEFAULT-NEXT:    bic lr, r2, lr
@@ -565,8 +565,8 @@ define <2 x float> @ct_v2f32(i1 %cond, <2 x float> %a, <2 x float> %b) {
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r0, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r1, lr
-; THUMB2-NEXT:    ldr r2, [sp, #12]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldr r2, [sp, #12]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r1, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r2, lr
@@ -580,12 +580,12 @@ entry:
 define <16 x i8> @ct_v16i8(i1 %cond, <16 x i8> %a, <16 x i8> %b) {
 ; CT-LABEL: ct_v16i8:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    add r1, sp, #8
-; CT-NEXT:    and r0, r0, #1
-; CT-NEXT:    vld1.64 {d18, d19}, [r1]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vldr d17, [sp]
+; CT-NEXT:    add r1, sp, #8
 ; CT-NEXT:    vmov d16, r2, r3
+; CT-NEXT:    vld1.64 {d18, d19}, [r1]
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 q11, r1
 ; CT-NEXT:    vand q10, q8, q11
 ; CT-NEXT:    vbic q11, q9, q11
@@ -604,105 +604,105 @@ define <16 x i8> @ct_v16i8(i1 %cond, <16 x i8> %a, <16 x i8> %b) {
 ; DEFAULT-NEXT:    and r4, r1, r5
 ; DEFAULT-NEXT:    bic r5, r12, r5
 ; DEFAULT-NEXT:    orr r4, r4, r5
+; DEFAULT-NEXT:    strb r4, [r0, #15]
 ; DEFAULT-NEXT:    ldrb r12, [sp, #128]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #64]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #15]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #124]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #14]
+; DEFAULT-NEXT:    ldrb r12, [sp, #124]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #60]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #14]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #120]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #13]
+; DEFAULT-NEXT:    ldrb r12, [sp, #120]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #56]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #13]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #116]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #12]
+; DEFAULT-NEXT:    ldrb r12, [sp, #116]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #52]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #12]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #112]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #11]
+; DEFAULT-NEXT:    ldrb r12, [sp, #112]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #48]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #11]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #108]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #10]
+; DEFAULT-NEXT:    ldrb r12, [sp, #108]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #44]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #10]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #104]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #9]
+; DEFAULT-NEXT:    ldrb r12, [sp, #104]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #40]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #9]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #100]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #8]
+; DEFAULT-NEXT:    ldrb r12, [sp, #100]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #36]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #8]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #96]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #7]
+; DEFAULT-NEXT:    ldrb r12, [sp, #96]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #32]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #7]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #92]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #6]
+; DEFAULT-NEXT:    ldrb r12, [sp, #92]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #28]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #6]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #88]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #5]
+; DEFAULT-NEXT:    ldrb r12, [sp, #88]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #24]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #5]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #84]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #4]
+; DEFAULT-NEXT:    ldrb r12, [sp, #84]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #20]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #4]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrb r12, [sp, #80]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strb r4, [r0, #3]
+; DEFAULT-NEXT:    ldrb r12, [sp, #80]
 ; DEFAULT-NEXT:    ldrb r5, [sp, #16]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strb r4, [r0, #3]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
 ; DEFAULT-NEXT:    orr r4, r4, r1
-; DEFAULT-NEXT:    ldrb r1, [sp, #76]
 ; DEFAULT-NEXT:    strb r4, [r0, #2]
+; DEFAULT-NEXT:    ldrb r1, [sp, #76]
 ; DEFAULT-NEXT:    rsb r4, lr, #0
 ; DEFAULT-NEXT:    and r5, r3, r4
 ; DEFAULT-NEXT:    bic r4, r1, r4
 ; DEFAULT-NEXT:    orr r5, r5, r4
-; DEFAULT-NEXT:    ldrb r1, [sp, #72]
 ; DEFAULT-NEXT:    strb r5, [r0, #1]
+; DEFAULT-NEXT:    ldrb r1, [sp, #72]
 ; DEFAULT-NEXT:    rsb r5, lr, #0
 ; DEFAULT-NEXT:    and r3, r2, r5
 ; DEFAULT-NEXT:    bic r5, r1, r5
@@ -890,105 +890,105 @@ define <16 x i8> @ct_v16i8(i1 %cond, <16 x i8> %a, <16 x i8> %b) {
 ; THUMB2-NEXT:    and.w r4, r1, r5
 ; THUMB2-NEXT:    bic.w r5, r12, r5
 ; THUMB2-NEXT:    orrs r4, r5
+; THUMB2-NEXT:    strb r4, [r0, #15]
 ; THUMB2-NEXT:    ldrb.w r12, [sp, #128]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #64]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #15]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #124]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #14]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #124]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #60]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #14]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #120]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #13]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #120]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #56]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #13]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #116]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #12]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #116]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #52]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #12]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #112]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #11]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #112]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #48]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #11]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #108]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #10]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #108]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #44]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #10]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #104]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #9]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #104]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #40]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #9]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #100]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #8]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #100]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #36]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #8]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #96]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #7]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #96]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #32]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #7]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #92]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #6]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #92]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #28]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #6]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #88]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #5]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #88]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #24]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #5]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #84]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #4]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #84]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #20]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #4]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrb.w r12, [sp, #80]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strb r4, [r0, #3]
+; THUMB2-NEXT:    ldrb.w r12, [sp, #80]
 ; THUMB2-NEXT:    ldrb.w r5, [sp, #16]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strb r4, [r0, #3]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
 ; THUMB2-NEXT:    orrs r4, r1
-; THUMB2-NEXT:    ldrb.w r1, [sp, #76]
 ; THUMB2-NEXT:    strb r4, [r0, #2]
+; THUMB2-NEXT:    ldrb.w r1, [sp, #76]
 ; THUMB2-NEXT:    rsb.w r4, lr, #0
 ; THUMB2-NEXT:    and.w r5, r3, r4
 ; THUMB2-NEXT:    bic.w r4, r1, r4
 ; THUMB2-NEXT:    orrs r5, r4
-; THUMB2-NEXT:    ldrb.w r1, [sp, #72]
 ; THUMB2-NEXT:    strb r5, [r0, #1]
+; THUMB2-NEXT:    ldrb.w r1, [sp, #72]
 ; THUMB2-NEXT:    rsb.w r5, lr, #0
 ; THUMB2-NEXT:    and.w r3, r2, r5
 ; THUMB2-NEXT:    bic.w r5, r1, r5
@@ -1003,12 +1003,12 @@ entry:
 define <8 x i16> @ct_v8i16(i1 %cond, <8 x i16> %a, <8 x i16> %b) {
 ; CT-LABEL: ct_v8i16:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    add r1, sp, #8
-; CT-NEXT:    and r0, r0, #1
-; CT-NEXT:    vld1.64 {d18, d19}, [r1]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vldr d17, [sp]
+; CT-NEXT:    add r1, sp, #8
 ; CT-NEXT:    vmov d16, r2, r3
+; CT-NEXT:    vld1.64 {d18, d19}, [r1]
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 q11, r1
 ; CT-NEXT:    vand q10, q8, q11
 ; CT-NEXT:    vbic q11, q9, q11
@@ -1027,49 +1027,49 @@ define <8 x i16> @ct_v8i16(i1 %cond, <8 x i16> %a, <8 x i16> %b) {
 ; DEFAULT-NEXT:    and r4, r1, r5
 ; DEFAULT-NEXT:    bic r5, r12, r5
 ; DEFAULT-NEXT:    orr r4, r4, r5
+; DEFAULT-NEXT:    strh r4, [r0, #14]
 ; DEFAULT-NEXT:    ldrh r12, [sp, #64]
 ; DEFAULT-NEXT:    ldrh r5, [sp, #32]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strh r4, [r0, #14]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrh r12, [sp, #60]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strh r4, [r0, #12]
+; DEFAULT-NEXT:    ldrh r12, [sp, #60]
 ; DEFAULT-NEXT:    ldrh r5, [sp, #28]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strh r4, [r0, #12]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrh r12, [sp, #56]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strh r4, [r0, #10]
+; DEFAULT-NEXT:    ldrh r12, [sp, #56]
 ; DEFAULT-NEXT:    ldrh r5, [sp, #24]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strh r4, [r0, #10]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrh r12, [sp, #52]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strh r4, [r0, #8]
+; DEFAULT-NEXT:    ldrh r12, [sp, #52]
 ; DEFAULT-NEXT:    ldrh r5, [sp, #20]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strh r4, [r0, #8]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
-; DEFAULT-NEXT:    ldrh r12, [sp, #48]
 ; DEFAULT-NEXT:    orr r4, r4, r1
+; DEFAULT-NEXT:    strh r4, [r0, #6]
+; DEFAULT-NEXT:    ldrh r12, [sp, #48]
 ; DEFAULT-NEXT:    ldrh r5, [sp, #16]
 ; DEFAULT-NEXT:    rsb r1, lr, #0
-; DEFAULT-NEXT:    strh r4, [r0, #6]
 ; DEFAULT-NEXT:    and r4, r5, r1
 ; DEFAULT-NEXT:    bic r1, r12, r1
 ; DEFAULT-NEXT:    orr r4, r4, r1
-; DEFAULT-NEXT:    ldrh r1, [sp, #44]
 ; DEFAULT-NEXT:    strh r4, [r0, #4]
+; DEFAULT-NEXT:    ldrh r1, [sp, #44]
 ; DEFAULT-NEXT:    rsb r4, lr, #0
 ; DEFAULT-NEXT:    and r5, r3, r4
 ; DEFAULT-NEXT:    bic r4, r1, r4
 ; DEFAULT-NEXT:    orr r5, r5, r4
-; DEFAULT-NEXT:    ldrh r1, [sp, #40]
 ; DEFAULT-NEXT:    strh r5, [r0, #2]
+; DEFAULT-NEXT:    ldrh r1, [sp, #40]
 ; DEFAULT-NEXT:    rsb r5, lr, #0
 ; DEFAULT-NEXT:    and r3, r2, r5
 ; DEFAULT-NEXT:    bic r5, r1, r5
@@ -1177,49 +1177,49 @@ define <8 x i16> @ct_v8i16(i1 %cond, <8 x i16> %a, <8 x i16> %b) {
 ; THUMB2-NEXT:    and.w r4, r1, r5
 ; THUMB2-NEXT:    bic.w r5, r12, r5
 ; THUMB2-NEXT:    orrs r4, r5
+; THUMB2-NEXT:    strh r4, [r0, #14]
 ; THUMB2-NEXT:    ldrh.w r12, [sp, #64]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #32]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #14]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrh.w r12, [sp, #60]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strh r4, [r0, #12]
+; THUMB2-NEXT:    ldrh.w r12, [sp, #60]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #28]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #12]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrh.w r12, [sp, #56]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strh r4, [r0, #10]
+; THUMB2-NEXT:    ldrh.w r12, [sp, #56]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #24]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #10]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrh.w r12, [sp, #52]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strh r4, [r0, #8]
+; THUMB2-NEXT:    ldrh.w r12, [sp, #52]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #20]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #8]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
-; THUMB2-NEXT:    ldrh.w r12, [sp, #48]
 ; THUMB2-NEXT:    orrs r4, r1
+; THUMB2-NEXT:    strh r4, [r0, #6]
+; THUMB2-NEXT:    ldrh.w r12, [sp, #48]
 ; THUMB2-NEXT:    ldrh.w r5, [sp, #16]
 ; THUMB2-NEXT:    rsb.w r1, lr, #0
-; THUMB2-NEXT:    strh r4, [r0, #6]
 ; THUMB2-NEXT:    and.w r4, r5, r1
 ; THUMB2-NEXT:    bic.w r1, r12, r1
 ; THUMB2-NEXT:    orrs r4, r1
-; THUMB2-NEXT:    ldrh.w r1, [sp, #44]
 ; THUMB2-NEXT:    strh r4, [r0, #4]
+; THUMB2-NEXT:    ldrh.w r1, [sp, #44]
 ; THUMB2-NEXT:    rsb.w r4, lr, #0
 ; THUMB2-NEXT:    and.w r5, r3, r4
 ; THUMB2-NEXT:    bic.w r4, r1, r4
 ; THUMB2-NEXT:    orrs r5, r4
-; THUMB2-NEXT:    ldrh.w r1, [sp, #40]
 ; THUMB2-NEXT:    strh r5, [r0, #2]
+; THUMB2-NEXT:    ldrh.w r1, [sp, #40]
 ; THUMB2-NEXT:    rsb.w r5, lr, #0
 ; THUMB2-NEXT:    and.w r3, r2, r5
 ; THUMB2-NEXT:    bic.w r5, r1, r5
@@ -1234,12 +1234,12 @@ entry:
 define <4 x i32> @ct_v4i32(i1 %cond, <4 x i32> %a, <4 x i32> %b) {
 ; CT-LABEL: ct_v4i32:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    add r1, sp, #8
-; CT-NEXT:    and r0, r0, #1
-; CT-NEXT:    vld1.64 {d18, d19}, [r1]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vldr d17, [sp]
+; CT-NEXT:    add r1, sp, #8
 ; CT-NEXT:    vmov d16, r2, r3
+; CT-NEXT:    vld1.64 {d18, d19}, [r1]
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 q11, r1
 ; CT-NEXT:    vand q10, q8, q11
 ; CT-NEXT:    vbic q11, q9, q11
@@ -1254,23 +1254,23 @@ define <4 x i32> @ct_v4i32(i1 %cond, <4 x i32> %a, <4 x i32> %b) {
 ; DEFAULT-NEXT:    and r12, r0, #1
 ; DEFAULT-NEXT:    ldr r1, [sp, #24]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
-; DEFAULT-NEXT:    rsb r4, r12, #0
 ; DEFAULT-NEXT:    and r0, r2, lr
 ; DEFAULT-NEXT:    bic lr, r1, lr
-; DEFAULT-NEXT:    ldr r2, [sp, #28]
 ; DEFAULT-NEXT:    orr r0, r0, lr
+; DEFAULT-NEXT:    ldr r2, [sp, #28]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
-; DEFAULT-NEXT:    rsb r5, r12, #0
 ; DEFAULT-NEXT:    and r1, r3, lr
 ; DEFAULT-NEXT:    bic lr, r2, lr
 ; DEFAULT-NEXT:    orr r1, r1, lr
 ; DEFAULT-NEXT:    ldr r3, [sp, #16]
 ; DEFAULT-NEXT:    ldr lr, [sp, #32]
+; DEFAULT-NEXT:    rsb r4, r12, #0
 ; DEFAULT-NEXT:    and r2, r3, r4
 ; DEFAULT-NEXT:    bic r4, lr, r4
-; DEFAULT-NEXT:    ldr lr, [sp, #36]
 ; DEFAULT-NEXT:    orr r2, r2, r4
+; DEFAULT-NEXT:    ldr lr, [sp, #36]
 ; DEFAULT-NEXT:    ldr r4, [sp, #20]
+; DEFAULT-NEXT:    rsb r5, r12, #0
 ; DEFAULT-NEXT:    and r3, r4, r5
 ; DEFAULT-NEXT:    bic r5, lr, r5
 ; DEFAULT-NEXT:    orr r3, r3, r5
@@ -1328,23 +1328,23 @@ define <4 x i32> @ct_v4i32(i1 %cond, <4 x i32> %a, <4 x i32> %b) {
 ; THUMB2-NEXT:    and r12, r0, #1
 ; THUMB2-NEXT:    ldr r1, [sp, #24]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r0, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r1, lr
-; THUMB2-NEXT:    ldr r2, [sp, #28]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldr r2, [sp, #28]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r1, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r2, lr
 ; THUMB2-NEXT:    orr.w r1, r1, lr
 ; THUMB2-NEXT:    ldr r3, [sp, #16]
 ; THUMB2-NEXT:    ldr.w lr, [sp, #32]
+; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r2, r3, r4
 ; THUMB2-NEXT:    bic.w r4, lr, r4
-; THUMB2-NEXT:    ldr.w lr, [sp, #36]
 ; THUMB2-NEXT:    orrs r2, r4
+; THUMB2-NEXT:    ldr.w lr, [sp, #36]
 ; THUMB2-NEXT:    ldr r4, [sp, #20]
+; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r3, r4, r5
 ; THUMB2-NEXT:    bic.w r5, lr, r5
 ; THUMB2-NEXT:    orrs r3, r5
@@ -1357,12 +1357,12 @@ entry:
 define <2 x i64> @ct_v2i64(i1 %cond, <2 x i64> %a, <2 x i64> %b) {
 ; CT-LABEL: ct_v2i64:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    add r1, sp, #8
-; CT-NEXT:    and r0, r0, #1
-; CT-NEXT:    vld1.64 {d18, d19}, [r1]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vldr d17, [sp]
+; CT-NEXT:    add r1, sp, #8
 ; CT-NEXT:    vmov d16, r2, r3
+; CT-NEXT:    vld1.64 {d18, d19}, [r1]
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 q11, r1
 ; CT-NEXT:    vand q10, q8, q11
 ; CT-NEXT:    vbic q11, q9, q11
@@ -1377,23 +1377,23 @@ define <2 x i64> @ct_v2i64(i1 %cond, <2 x i64> %a, <2 x i64> %b) {
 ; DEFAULT-NEXT:    and r12, r0, #1
 ; DEFAULT-NEXT:    ldr r1, [sp, #24]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
-; DEFAULT-NEXT:    rsb r4, r12, #0
 ; DEFAULT-NEXT:    and r0, r2, lr
 ; DEFAULT-NEXT:    bic lr, r1, lr
-; DEFAULT-NEXT:    ldr r2, [sp, #28]
 ; DEFAULT-NEXT:    orr r0, r0, lr
+; DEFAULT-NEXT:    ldr r2, [sp, #28]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
-; DEFAULT-NEXT:    rsb r5, r12, #0
 ; DEFAULT-NEXT:    and r1, r3, lr
 ; DEFAULT-NEXT:    bic lr, r2, lr
 ; DEFAULT-NEXT:    orr r1, r1, lr
 ; DEFAULT-NEXT:    ldr r3, [sp, #16]
 ; DEFAULT-NEXT:    ldr lr, [sp, #32]
+; DEFAULT-NEXT:    rsb r4, r12, #0
 ; DEFAULT-NEXT:    and r2, r3, r4
 ; DEFAULT-NEXT:    bic r4, lr, r4
-; DEFAULT-NEXT:    ldr lr, [sp, #36]
 ; DEFAULT-NEXT:    orr r2, r2, r4
+; DEFAULT-NEXT:    ldr lr, [sp, #36]
 ; DEFAULT-NEXT:    ldr r4, [sp, #20]
+; DEFAULT-NEXT:    rsb r5, r12, #0
 ; DEFAULT-NEXT:    and r3, r4, r5
 ; DEFAULT-NEXT:    bic r5, lr, r5
 ; DEFAULT-NEXT:    orr r3, r3, r5
@@ -1451,23 +1451,23 @@ define <2 x i64> @ct_v2i64(i1 %cond, <2 x i64> %a, <2 x i64> %b) {
 ; THUMB2-NEXT:    and r12, r0, #1
 ; THUMB2-NEXT:    ldr r1, [sp, #24]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r0, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r1, lr
-; THUMB2-NEXT:    ldr r2, [sp, #28]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldr r2, [sp, #28]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r1, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r2, lr
 ; THUMB2-NEXT:    orr.w r1, r1, lr
 ; THUMB2-NEXT:    ldr r3, [sp, #16]
 ; THUMB2-NEXT:    ldr.w lr, [sp, #32]
+; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r2, r3, r4
 ; THUMB2-NEXT:    bic.w r4, lr, r4
-; THUMB2-NEXT:    ldr.w lr, [sp, #36]
 ; THUMB2-NEXT:    orrs r2, r4
+; THUMB2-NEXT:    ldr.w lr, [sp, #36]
 ; THUMB2-NEXT:    ldr r4, [sp, #20]
+; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r3, r4, r5
 ; THUMB2-NEXT:    bic.w r5, lr, r5
 ; THUMB2-NEXT:    orrs r3, r5
@@ -1480,12 +1480,12 @@ entry:
 define <4 x float> @ct_v4f32(i1 %cond, <4 x float> %a, <4 x float> %b) {
 ; CT-LABEL: ct_v4f32:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    add r1, sp, #8
-; CT-NEXT:    and r0, r0, #1
-; CT-NEXT:    vld1.64 {d18, d19}, [r1]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vldr d17, [sp]
+; CT-NEXT:    add r1, sp, #8
 ; CT-NEXT:    vmov d16, r2, r3
+; CT-NEXT:    vld1.64 {d18, d19}, [r1]
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 q11, r1
 ; CT-NEXT:    vand q10, q8, q11
 ; CT-NEXT:    vbic q11, q9, q11
@@ -1500,23 +1500,23 @@ define <4 x float> @ct_v4f32(i1 %cond, <4 x float> %a, <4 x float> %b) {
 ; DEFAULT-NEXT:    and r12, r0, #1
 ; DEFAULT-NEXT:    ldr r1, [sp, #24]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
-; DEFAULT-NEXT:    rsb r4, r12, #0
 ; DEFAULT-NEXT:    and r0, r2, lr
 ; DEFAULT-NEXT:    bic lr, r1, lr
-; DEFAULT-NEXT:    ldr r2, [sp, #28]
 ; DEFAULT-NEXT:    orr r0, r0, lr
+; DEFAULT-NEXT:    ldr r2, [sp, #28]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
-; DEFAULT-NEXT:    rsb r5, r12, #0
 ; DEFAULT-NEXT:    and r1, r3, lr
 ; DEFAULT-NEXT:    bic lr, r2, lr
 ; DEFAULT-NEXT:    orr r1, r1, lr
 ; DEFAULT-NEXT:    ldr r3, [sp, #16]
 ; DEFAULT-NEXT:    ldr lr, [sp, #32]
+; DEFAULT-NEXT:    rsb r4, r12, #0
 ; DEFAULT-NEXT:    and r2, r3, r4
 ; DEFAULT-NEXT:    bic r4, lr, r4
-; DEFAULT-NEXT:    ldr lr, [sp, #36]
 ; DEFAULT-NEXT:    orr r2, r2, r4
+; DEFAULT-NEXT:    ldr lr, [sp, #36]
 ; DEFAULT-NEXT:    ldr r4, [sp, #20]
+; DEFAULT-NEXT:    rsb r5, r12, #0
 ; DEFAULT-NEXT:    and r3, r4, r5
 ; DEFAULT-NEXT:    bic r5, lr, r5
 ; DEFAULT-NEXT:    orr r3, r3, r5
@@ -1574,23 +1574,23 @@ define <4 x float> @ct_v4f32(i1 %cond, <4 x float> %a, <4 x float> %b) {
 ; THUMB2-NEXT:    and r12, r0, #1
 ; THUMB2-NEXT:    ldr r1, [sp, #24]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r0, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r1, lr
-; THUMB2-NEXT:    ldr r2, [sp, #28]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldr r2, [sp, #28]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r1, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r2, lr
 ; THUMB2-NEXT:    orr.w r1, r1, lr
 ; THUMB2-NEXT:    ldr r3, [sp, #16]
 ; THUMB2-NEXT:    ldr.w lr, [sp, #32]
+; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r2, r3, r4
 ; THUMB2-NEXT:    bic.w r4, lr, r4
-; THUMB2-NEXT:    ldr.w lr, [sp, #36]
 ; THUMB2-NEXT:    orrs r2, r4
+; THUMB2-NEXT:    ldr.w lr, [sp, #36]
 ; THUMB2-NEXT:    ldr r4, [sp, #20]
+; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r3, r4, r5
 ; THUMB2-NEXT:    bic.w r5, lr, r5
 ; THUMB2-NEXT:    orrs r3, r5
@@ -1603,12 +1603,12 @@ entry:
 define <2 x double> @ct_v2f64(i1 %cond, <2 x double> %a, <2 x double> %b) {
 ; CT-LABEL: ct_v2f64:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    add r1, sp, #8
-; CT-NEXT:    and r0, r0, #1
-; CT-NEXT:    vld1.64 {d18, d19}, [r1]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vldr d17, [sp]
+; CT-NEXT:    add r1, sp, #8
 ; CT-NEXT:    vmov d16, r2, r3
+; CT-NEXT:    vld1.64 {d18, d19}, [r1]
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 q11, r1
 ; CT-NEXT:    vand q10, q8, q11
 ; CT-NEXT:    vbic q11, q9, q11
@@ -1623,23 +1623,23 @@ define <2 x double> @ct_v2f64(i1 %cond, <2 x double> %a, <2 x double> %b) {
 ; DEFAULT-NEXT:    and r12, r0, #1
 ; DEFAULT-NEXT:    ldr r1, [sp, #24]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
-; DEFAULT-NEXT:    rsb r4, r12, #0
 ; DEFAULT-NEXT:    and r0, r2, lr
 ; DEFAULT-NEXT:    bic lr, r1, lr
-; DEFAULT-NEXT:    ldr r2, [sp, #28]
 ; DEFAULT-NEXT:    orr r0, r0, lr
+; DEFAULT-NEXT:    ldr r2, [sp, #28]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
-; DEFAULT-NEXT:    rsb r5, r12, #0
 ; DEFAULT-NEXT:    and r1, r3, lr
 ; DEFAULT-NEXT:    bic lr, r2, lr
 ; DEFAULT-NEXT:    orr r1, r1, lr
 ; DEFAULT-NEXT:    ldr r3, [sp, #16]
 ; DEFAULT-NEXT:    ldr lr, [sp, #32]
+; DEFAULT-NEXT:    rsb r4, r12, #0
 ; DEFAULT-NEXT:    and r2, r3, r4
 ; DEFAULT-NEXT:    bic r4, lr, r4
-; DEFAULT-NEXT:    ldr lr, [sp, #36]
 ; DEFAULT-NEXT:    orr r2, r2, r4
+; DEFAULT-NEXT:    ldr lr, [sp, #36]
 ; DEFAULT-NEXT:    ldr r4, [sp, #20]
+; DEFAULT-NEXT:    rsb r5, r12, #0
 ; DEFAULT-NEXT:    and r3, r4, r5
 ; DEFAULT-NEXT:    bic r5, lr, r5
 ; DEFAULT-NEXT:    orr r3, r3, r5
@@ -1697,23 +1697,23 @@ define <2 x double> @ct_v2f64(i1 %cond, <2 x double> %a, <2 x double> %b) {
 ; THUMB2-NEXT:    and r12, r0, #1
 ; THUMB2-NEXT:    ldr r1, [sp, #24]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r0, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r1, lr
-; THUMB2-NEXT:    ldr r2, [sp, #28]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldr r2, [sp, #28]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
-; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r1, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r2, lr
 ; THUMB2-NEXT:    orr.w r1, r1, lr
 ; THUMB2-NEXT:    ldr r3, [sp, #16]
 ; THUMB2-NEXT:    ldr.w lr, [sp, #32]
+; THUMB2-NEXT:    rsb.w r4, r12, #0
 ; THUMB2-NEXT:    and.w r2, r3, r4
 ; THUMB2-NEXT:    bic.w r4, lr, r4
-; THUMB2-NEXT:    ldr.w lr, [sp, #36]
 ; THUMB2-NEXT:    orrs r2, r4
+; THUMB2-NEXT:    ldr.w lr, [sp, #36]
 ; THUMB2-NEXT:    ldr r4, [sp, #20]
+; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r3, r4, r5
 ; THUMB2-NEXT:    bic.w r5, lr, r5
 ; THUMB2-NEXT:    orrs r3, r5
@@ -1776,10 +1776,10 @@ entry:
 define <2 x i8> @ct_v2i8(i1 %cond, <2 x i8> %a, <2 x i8> %b) {
 ; CT-LABEL: ct_v2i8:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    vldr d16, [sp]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vmov d17, r2, r3
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 d19, r1
 ; CT-NEXT:    vand d18, d17, d19
 ; CT-NEXT:    vbic d19, d16, d19
@@ -1794,8 +1794,8 @@ define <2 x i8> @ct_v2i8(i1 %cond, <2 x i8> %a, <2 x i8> %b) {
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r0, r1, lr
 ; DEFAULT-NEXT:    bic lr, r3, lr
-; DEFAULT-NEXT:    ldrb r3, [sp, #8]
 ; DEFAULT-NEXT:    orr r0, r0, lr
+; DEFAULT-NEXT:    ldrb r3, [sp, #8]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r1, r2, lr
 ; DEFAULT-NEXT:    bic lr, r3, lr
@@ -1833,8 +1833,8 @@ define <2 x i8> @ct_v2i8(i1 %cond, <2 x i8> %a, <2 x i8> %b) {
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r0, r1, lr
 ; THUMB2-NEXT:    bic.w lr, r3, lr
-; THUMB2-NEXT:    ldrb.w r3, [sp, #8]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldrb.w r3, [sp, #8]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r1, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r3, lr
@@ -1848,10 +1848,10 @@ entry:
 define <4 x i8> @ct_v4i8(i1 %cond, <4 x i8> %a, <4 x i8> %b) {
 ; CT-LABEL: ct_v4i8:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    vldr d16, [sp]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vmov d17, r2, r3
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 d19, r1
 ; CT-NEXT:    vand d18, d17, d19
 ; CT-NEXT:    vbic d19, d16, d19
@@ -1865,7 +1865,6 @@ define <4 x i8> @ct_v4i8(i1 %cond, <4 x i8> %a, <4 x i8> %b) {
 ; DEFAULT-NEXT:    and r12, r0, #1
 ; DEFAULT-NEXT:    ldrb lr, [sp, #20]
 ; DEFAULT-NEXT:    rsb r4, r12, #0
-; DEFAULT-NEXT:    rsb r5, r12, #0
 ; DEFAULT-NEXT:    and r0, r1, r4
 ; DEFAULT-NEXT:    bic r4, lr, r4
 ; DEFAULT-NEXT:    orr r0, r0, r4
@@ -1873,14 +1872,15 @@ define <4 x i8> @ct_v4i8(i1 %cond, <4 x i8> %a, <4 x i8> %b) {
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r1, r2, lr
 ; DEFAULT-NEXT:    bic lr, r4, lr
-; DEFAULT-NEXT:    ldrb r4, [sp, #28]
 ; DEFAULT-NEXT:    orr r1, r1, lr
+; DEFAULT-NEXT:    ldrb r4, [sp, #28]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r2, r3, lr
 ; DEFAULT-NEXT:    bic lr, r4, lr
 ; DEFAULT-NEXT:    orr r2, r2, lr
-; DEFAULT-NEXT:    ldrb r4, [sp, #16]
 ; DEFAULT-NEXT:    ldrb lr, [sp, #32]
+; DEFAULT-NEXT:    ldrb r4, [sp, #16]
+; DEFAULT-NEXT:    rsb r5, r12, #0
 ; DEFAULT-NEXT:    and r3, r4, r5
 ; DEFAULT-NEXT:    bic r5, lr, r5
 ; DEFAULT-NEXT:    orr r3, r3, r5
@@ -1934,7 +1934,6 @@ define <4 x i8> @ct_v4i8(i1 %cond, <4 x i8> %a, <4 x i8> %b) {
 ; THUMB2-NEXT:    and r12, r0, #1
 ; THUMB2-NEXT:    ldrb.w lr, [sp, #20]
 ; THUMB2-NEXT:    rsb.w r4, r12, #0
-; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r0, r1, r4
 ; THUMB2-NEXT:    bic.w r4, lr, r4
 ; THUMB2-NEXT:    orrs r0, r4
@@ -1942,14 +1941,15 @@ define <4 x i8> @ct_v4i8(i1 %cond, <4 x i8> %a, <4 x i8> %b) {
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r1, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r4, lr
-; THUMB2-NEXT:    ldrb.w r4, [sp, #28]
 ; THUMB2-NEXT:    orr.w r1, r1, lr
+; THUMB2-NEXT:    ldrb.w r4, [sp, #28]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r2, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r4, lr
 ; THUMB2-NEXT:    orr.w r2, r2, lr
-; THUMB2-NEXT:    ldrb.w r4, [sp, #16]
 ; THUMB2-NEXT:    ldrb.w lr, [sp, #32]
+; THUMB2-NEXT:    ldrb.w r4, [sp, #16]
+; THUMB2-NEXT:    rsb.w r5, r12, #0
 ; THUMB2-NEXT:    and.w r3, r4, r5
 ; THUMB2-NEXT:    bic.w r5, lr, r5
 ; THUMB2-NEXT:    orrs r3, r5
@@ -2009,10 +2009,10 @@ entry:
 define <2 x i16> @ct_v2i16(i1 %cond, <2 x i16> %a, <2 x i16> %b) {
 ; CT-LABEL: ct_v2i16:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    vldr d16, [sp]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vmov d17, r2, r3
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 d19, r1
 ; CT-NEXT:    vand d18, d17, d19
 ; CT-NEXT:    vbic d19, d16, d19
@@ -2027,8 +2027,8 @@ define <2 x i16> @ct_v2i16(i1 %cond, <2 x i16> %a, <2 x i16> %b) {
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r0, r1, lr
 ; DEFAULT-NEXT:    bic lr, r3, lr
-; DEFAULT-NEXT:    ldrh r3, [sp, #8]
 ; DEFAULT-NEXT:    orr r0, r0, lr
+; DEFAULT-NEXT:    ldrh r3, [sp, #8]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r1, r2, lr
 ; DEFAULT-NEXT:    bic lr, r3, lr
@@ -2066,8 +2066,8 @@ define <2 x i16> @ct_v2i16(i1 %cond, <2 x i16> %a, <2 x i16> %b) {
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r0, r1, lr
 ; THUMB2-NEXT:    bic.w lr, r3, lr
-; THUMB2-NEXT:    ldrh.w r3, [sp, #8]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldrh.w r3, [sp, #8]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r1, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r3, lr
@@ -2128,12 +2128,12 @@ entry:
 define <1 x float> @ct_v1f32(i1 %cond, <1 x float> %a, <1 x float> %b) {
 ; CT-LABEL: ct_v1f32:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    vmov s0, r2
 ; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    vmov s0, r2
 ; CT-NEXT:    vmov s2, r1
-; CT-NEXT:    rsb r1, r0, #0
-; CT-NEXT:    vmov r3, s0
 ; CT-NEXT:    vmov r2, s2
+; CT-NEXT:    vmov r3, s0
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    and r2, r2, r1
 ; CT-NEXT:    bic r1, r3, r1
 ; CT-NEXT:    orr r2, r2, r1

--- a/llvm/test/CodeGen/ARM/ctselect.ll
+++ b/llvm/test/CodeGen/ARM/ctselect.ll
@@ -271,16 +271,16 @@ define i64 @ct_int64(i1 %cond, i64 %a, i64 %b) {
 ; CT:       @ %bb.0: @ %entry
 ; CT-NEXT:    .save {r4, lr}
 ; CT-NEXT:    push {r4, lr}
+; CT-NEXT:    ldr r1, [sp, #8]
 ; CT-NEXT:    and lr, r0, #1
 ; CT-NEXT:    ldr r12, [sp, #12]
 ; CT-NEXT:    rsb r4, lr, #0
-; CT-NEXT:    ldr r1, [sp, #8]
 ; CT-NEXT:    and r0, r2, r4
-; CT-NEXT:    rsb r2, lr, #0
 ; CT-NEXT:    bic r4, r1, r4
+; CT-NEXT:    orr r0, r0, r4
+; CT-NEXT:    rsb r2, lr, #0
 ; CT-NEXT:    and r1, r3, r2
 ; CT-NEXT:    bic r2, r12, r2
-; CT-NEXT:    orr r0, r0, r4
 ; CT-NEXT:    orr r1, r1, r2
 ; CT-NEXT:    pop {r4, pc}
 ;
@@ -292,8 +292,8 @@ define i64 @ct_int64(i1 %cond, i64 %a, i64 %b) {
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r0, r2, lr
 ; DEFAULT-NEXT:    bic lr, r1, lr
-; DEFAULT-NEXT:    ldr r2, [sp, #12]
 ; DEFAULT-NEXT:    orr r0, r0, lr
+; DEFAULT-NEXT:    ldr r2, [sp, #12]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r1, r3, lr
 ; DEFAULT-NEXT:    bic lr, r2, lr
@@ -333,8 +333,8 @@ define i64 @ct_int64(i1 %cond, i64 %a, i64 %b) {
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r0, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r1, lr
-; THUMB2-NEXT:    ldr r2, [sp, #12]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldr r2, [sp, #12]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r1, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r2, lr
@@ -345,15 +345,15 @@ define i64 @ct_int64(i1 %cond, i64 %a, i64 %b) {
 ; CORTEXA9:       @ %bb.0: @ %entry
 ; CORTEXA9-NEXT:    .save {r4, lr}
 ; CORTEXA9-NEXT:    push {r4, lr}
-; CORTEXA9-NEXT:    and lr, r0, #1
 ; CORTEXA9-NEXT:    ldrd r1, r12, [sp, #8]
+; CORTEXA9-NEXT:    and lr, r0, #1
 ; CORTEXA9-NEXT:    rsb.w r4, lr, #0
 ; CORTEXA9-NEXT:    and.w r0, r2, r4
-; CORTEXA9-NEXT:    rsb.w r2, lr, #0
 ; CORTEXA9-NEXT:    bic.w r4, r1, r4
+; CORTEXA9-NEXT:    orrs r0, r4
+; CORTEXA9-NEXT:    rsb.w r2, lr, #0
 ; CORTEXA9-NEXT:    and.w r1, r3, r2
 ; CORTEXA9-NEXT:    bic.w r2, r12, r2
-; CORTEXA9-NEXT:    orrs r0, r4
 ; CORTEXA9-NEXT:    orr.w r1, r1, r2
 ; CORTEXA9-NEXT:    pop {r4, pc}
 ;
@@ -361,16 +361,16 @@ define i64 @ct_int64(i1 %cond, i64 %a, i64 %b) {
 ; CORTEX-NOTHUMB:       @ %bb.0: @ %entry
 ; CORTEX-NOTHUMB-NEXT:    .save {r4, lr}
 ; CORTEX-NOTHUMB-NEXT:    push {r4, lr}
-; CORTEX-NOTHUMB-NEXT:    and lr, r0, #1
 ; CORTEX-NOTHUMB-NEXT:    ldr r12, [sp, #12]
+; CORTEX-NOTHUMB-NEXT:    and lr, r0, #1
 ; CORTEX-NOTHUMB-NEXT:    ldr r1, [sp, #8]
 ; CORTEX-NOTHUMB-NEXT:    rsb r4, lr, #0
 ; CORTEX-NOTHUMB-NEXT:    and r0, r2, r4
-; CORTEX-NOTHUMB-NEXT:    rsb r2, lr, #0
 ; CORTEX-NOTHUMB-NEXT:    bic r4, r1, r4
+; CORTEX-NOTHUMB-NEXT:    orr r0, r0, r4
+; CORTEX-NOTHUMB-NEXT:    rsb r2, lr, #0
 ; CORTEX-NOTHUMB-NEXT:    and r1, r3, r2
 ; CORTEX-NOTHUMB-NEXT:    bic r2, r12, r2
-; CORTEX-NOTHUMB-NEXT:    orr r0, r0, r4
 ; CORTEX-NOTHUMB-NEXT:    orr r1, r1, r2
 ; CORTEX-NOTHUMB-NEXT:    pop {r4, pc}
 entry:
@@ -381,12 +381,12 @@ entry:
 define float @ct_float(i1 %cond, float %a, float %b) {
 ; CT-LABEL: ct_float:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    vmov s0, r2
 ; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    vmov s0, r2
 ; CT-NEXT:    vmov s2, r1
-; CT-NEXT:    rsb r1, r0, #0
-; CT-NEXT:    vmov r3, s0
 ; CT-NEXT:    vmov r2, s2
+; CT-NEXT:    vmov r3, s0
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    and r2, r2, r1
 ; CT-NEXT:    bic r1, r3, r1
 ; CT-NEXT:    orr r2, r2, r1
@@ -460,10 +460,10 @@ entry:
 define double @ct_f64(i1 %cond, double %a, double %b) {
 ; CT-LABEL: ct_f64:
 ; CT:       @ %bb.0: @ %entry
-; CT-NEXT:    and r0, r0, #1
 ; CT-NEXT:    vldr d16, [sp]
-; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vmov d17, r2, r3
+; CT-NEXT:    and r0, r0, #1
+; CT-NEXT:    rsb r1, r0, #0
 ; CT-NEXT:    vdup.32 d19, r1
 ; CT-NEXT:    vand d18, d17, d19
 ; CT-NEXT:    vbic d19, d16, d19
@@ -479,8 +479,8 @@ define double @ct_f64(i1 %cond, double %a, double %b) {
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r0, r2, lr
 ; DEFAULT-NEXT:    bic lr, r1, lr
-; DEFAULT-NEXT:    ldr r2, [sp, #12]
 ; DEFAULT-NEXT:    orr r0, r0, lr
+; DEFAULT-NEXT:    ldr r2, [sp, #12]
 ; DEFAULT-NEXT:    rsb lr, r12, #0
 ; DEFAULT-NEXT:    and r1, r3, lr
 ; DEFAULT-NEXT:    bic lr, r2, lr
@@ -520,8 +520,8 @@ define double @ct_f64(i1 %cond, double %a, double %b) {
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r0, r2, lr
 ; THUMB2-NEXT:    bic.w lr, r1, lr
-; THUMB2-NEXT:    ldr r2, [sp, #12]
 ; THUMB2-NEXT:    orr.w r0, r0, lr
+; THUMB2-NEXT:    ldr r2, [sp, #12]
 ; THUMB2-NEXT:    rsb.w lr, r12, #0
 ; THUMB2-NEXT:    and.w r1, r3, lr
 ; THUMB2-NEXT:    bic.w lr, r2, lr
@@ -536,7 +536,7 @@ define double @ct_f64(i1 %cond, double %a, double %b) {
 ; CORTEXA9-NEXT:    vand d16, d0, d17
 ; CORTEXA9-NEXT:    vbic d17, d1, d17
 ; CORTEXA9-NEXT:    vorr d16, d16, d17
-; CORTEXA9-NEXT:    vorr d0, d16, d16
+; CORTEXA9-NEXT:    vmov.f64 d0, d16
 ; CORTEXA9-NEXT:    bx lr
 ;
 ; CORTEX-NOTHUMB-LABEL: ct_f64:
@@ -547,7 +547,7 @@ define double @ct_f64(i1 %cond, double %a, double %b) {
 ; CORTEX-NOTHUMB-NEXT:    vand d16, d0, d17
 ; CORTEX-NOTHUMB-NEXT:    vbic d17, d1, d17
 ; CORTEX-NOTHUMB-NEXT:    vorr d16, d16, d17
-; CORTEX-NOTHUMB-NEXT:    vorr d0, d16, d16
+; CORTEX-NOTHUMB-NEXT:    vmov.f64 d0, d16
 ; CORTEX-NOTHUMB-NEXT:    bx lr
 entry:
   %sel = call double @llvm.ct.select.f64(i1 %cond, double %a, double %b)


### PR DESCRIPTION
## Summary

This PR fixes machine code verification errors in the ARM Thumb1 constant-time select (`CTSELECT`) implementation. The issue was that Thumb1 instructions were being generated with incorrect operand counts, causing the LLVM machine verifier to fail.

## Problem

When running `update_llc_test_checks.py` on `llvm/test/CodeGen/ARM/ctselect.ll`, the following errors occurred:

```
*** Bad machine code: Too few operands ***
- instruction: $r4 = nomerge tLSLri $r4, 31, 14, $noreg
6 operands expected, but 5 given.
```

Similar errors occurred for `tASRri`, `tEOR`, and `tAND` instructions.
