### PR TITLE
Fix EFLAGS clobbering in ct_select at -Oz on i386

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -24946,6 +24946,33 @@ static SDValue LowerSIGN_EXTEND_Mask(SDValue Op, const SDLoc &dl,
   return V;
 }
 
+/// Helper to create appropriate CTSELECT node for target.
+/// For i386 without CMOV, materializes condition to byte to avoid EFLAGS sharing issues.
+static SDValue createTargetCTSELECT(SDLoc DL, MVT VT,
+                                     SDValue FalseOp, SDValue TrueOp,
+                                     SDValue CC, SDValue ProcessedCond,
+                                     SelectionDAG &DAG,
+                                     const X86Subtarget &Subtarget,
+                                     SDNodeFlags Flags = SDNodeFlags()) {
+  if (!Subtarget.hasCMOV() && !VT.isVector()) {
+    // Materialize condition for i386 to prevent EFLAGS sharing
+    // Extract condition code and materialize EFLAGS to byte immediately
+    auto *CCNode = dyn_cast<ConstantSDNode>(CC);
+    if (CCNode) {
+      X86::CondCode CCVal = static_cast<X86::CondCode>(CCNode->getZExtValue());
+      X86::CondCode OppCC = X86::GetOppositeBranchCondition(CCVal);
+      SDValue CondByte = getSETCC(OppCC, ProcessedCond, DL, DAG);
+      SDValue Ops[] = {FalseOp, TrueOp, CondByte};
+      return DAG.getNode(X86ISD::CTSELECT_I386, DL, VT, Ops, Flags);
+    }
+    // If CC is not constant, fall through to standard CTSELECT
+    // (This happens in some edge cases where condition code is dynamically computed)
+  }
+
+  SDValue Ops[] = {FalseOp, TrueOp, CC, ProcessedCond};
+  return DAG.getNode(X86ISD::CTSELECT, DL, VT, Ops, Flags);
+}
+
 SDValue X86TargetLowering::LowerCTSELECT(SDValue Op, SelectionDAG &DAG) const {
   SDValue Cond = Op.getOperand(0); // condition
   SDValue TrueOp = Op.getOperand(1);  // true_value
@@ -25080,8 +25107,9 @@ SDValue X86TargetLowering::LowerCTSELECT(SDValue Op, SelectionDAG &DAG) const {
     if (T1.getValueType() == T2.getValueType() &&
         T1.getOpcode() != ISD::CopyFromReg &&
         T2.getOpcode() != ISD::CopyFromReg) {
-      SDValue CtSelect = DAG.getNode(X86ISD::CTSELECT, DL, T1.getValueType(),
-                                     T2, T1, CC, ProcessedCond);
+      SDValue CtSelect = createTargetCTSELECT(DL, T1.getSimpleValueType(),
+                                               T2, T1, CC, ProcessedCond,
+                                               DAG, Subtarget);
       return DAG.getNode(ISD::TRUNCATE, DL, Op.getValueType(), CtSelect);
     }
   }
@@ -25094,8 +25122,9 @@ SDValue X86TargetLowering::LowerCTSELECT(SDValue Op, SelectionDAG &DAG) const {
        !X86::mayFoldLoad(FalseOp, Subtarget))) {
     TrueOp = DAG.getNode(ISD::ANY_EXTEND, DL, MVT::i32, TrueOp);
     FalseOp = DAG.getNode(ISD::ANY_EXTEND, DL, MVT::i32, FalseOp);
-    SDValue Ops[] = {FalseOp, TrueOp, CC, ProcessedCond};
-    SDValue CtSelect = DAG.getNode(X86ISD::CTSELECT, DL, MVT::i32, Ops);
+    SDValue CtSelect = createTargetCTSELECT(DL, MVT::i32,
+                                             FalseOp, TrueOp, CC, ProcessedCond,
+                                             DAG, Subtarget);
     return DAG.getNode(ISD::TRUNCATE, DL, Op.getValueType(), CtSelect);
   }
 
@@ -25103,15 +25132,16 @@ SDValue X86TargetLowering::LowerCTSELECT(SDValue Op, SelectionDAG &DAG) const {
     MVT IntVT = (VT == MVT::f32) ? MVT::i32 : MVT::i64;
     TrueOp = DAG.getBitcast(IntVT, TrueOp);
     FalseOp = DAG.getBitcast(IntVT, FalseOp);
-    SDValue Ops[] = {FalseOp, TrueOp, CC, ProcessedCond};
-    SDValue CtSelect = DAG.getNode(X86ISD::CTSELECT, DL, IntVT, Ops);
+    SDValue CtSelect = createTargetCTSELECT(DL, IntVT,
+                                             FalseOp, TrueOp, CC, ProcessedCond,
+                                             DAG, Subtarget);
     return DAG.getBitcast(VT, CtSelect);
   }
 
   // Create final CTSELECT node
-  SDValue Ops[] = {FalseOp, TrueOp, CC, ProcessedCond};
-  return DAG.getNode(X86ISD::CTSELECT, DL, Op.getValueType(), Ops,
-                     Op->getFlags());
+  return createTargetCTSELECT(DL, Op.getSimpleValueType(),
+                               FalseOp, TrueOp, CC, ProcessedCond,
+                               DAG, Subtarget, Op->getFlags());
 }
 
 static SDValue LowerANY_EXTEND(SDValue Op, const X86Subtarget &Subtarget,
@@ -34790,6 +34820,7 @@ const char *X86TargetLowering::getTargetNodeName(unsigned Opcode) const {
   NODE_NAME_CASE(CMPMM_SAE)
   NODE_NAME_CASE(SETCC)
   NODE_NAME_CASE(CTSELECT)
+  NODE_NAME_CASE(CTSELECT_I386)
   NODE_NAME_CASE(SETCC_CARRY)
   NODE_NAME_CASE(FSETCC)
   NODE_NAME_CASE(FSETCCM)
@@ -37634,6 +37665,50 @@ emitCTSelectI386WithConditionMaterialization(MachineInstr &MI,
   return BB;
 }
 
+static MachineBasicBlock *
+emitCTSelectI386WithByteCondition(MachineInstr &MI,
+                                   MachineBasicBlock *BB,
+                                   unsigned InternalPseudoOpcode) {
+  const TargetInstrInfo *TII = BB->getParent()->getSubtarget().getInstrInfo();
+  const MIMetadata MIMD(MI);
+  MachineFunction *MF = BB->getParent();
+  MachineRegisterInfo &MRI = MF->getRegInfo();
+
+  // Operands: (outs dst), (ins src1, src2, cond_byte)
+  Register DstReg = MI.getOperand(0).getReg();
+  Register Src1Reg = MI.getOperand(1).getReg();
+  Register Src2Reg = MI.getOperand(2).getReg();
+  Register CondByteReg = MI.getOperand(3).getReg(); // Pre-materialized at DAG level!
+
+  // Create virtual registers for the temporary outputs
+  Register TmpByteReg = MRI.createVirtualRegister(&X86::GR8RegClass);
+  Register TmpMaskReg;
+
+  // Determine register class for tmp_mask based on data type
+  if (InternalPseudoOpcode == X86::CTSELECT_I386_INT_GR8rr) {
+    TmpMaskReg = MRI.createVirtualRegister(&X86::GR8RegClass);
+  } else if (InternalPseudoOpcode == X86::CTSELECT_I386_INT_GR16rr) {
+    TmpMaskReg = MRI.createVirtualRegister(&X86::GR16RegClass);
+  } else if (InternalPseudoOpcode == X86::CTSELECT_I386_INT_GR32rr) {
+    TmpMaskReg = MRI.createVirtualRegister(&X86::GR32RegClass);
+  } else {
+    llvm_unreachable("Unknown internal pseudo opcode");
+  }
+
+  // Create internal pseudo with pre-materialized condition byte
+  // No SETCC needed - condition already materialized at DAG level!
+  BuildMI(*BB, MI, MIMD, TII->get(InternalPseudoOpcode))
+      .addDef(DstReg)
+      .addDef(TmpByteReg)
+      .addDef(TmpMaskReg)
+      .addReg(Src1Reg)
+      .addReg(Src2Reg)
+      .addReg(CondByteReg);  // Already materialized!
+
+  MI.eraseFromParent();
+  return BB;
+}
+
 // Helper structure to hold memory operand information for FP loads
 struct FPLoadMemOperands {
   bool IsValid = false;
@@ -37749,9 +37824,9 @@ static FPLoadMemOperands getFPLoadMemOperands(Register Reg,
   return Result;
 }
 
-static MachineBasicBlock *emitCTSelectI386WithFpType(MachineInstr &MI,
-                                                     MachineBasicBlock *BB,
-                                                     unsigned pseudoInstr) {
+/// FP constant-time select with pre-materialized condition byte.
+static MachineBasicBlock *emitCTSelectI386WithFpType(
+    MachineInstr &MI, MachineBasicBlock *BB, unsigned pseudoInstr) {
   const TargetInstrInfo *TII = BB->getParent()->getSubtarget().getInstrInfo();
   const MIMetadata MIMD(MI);
   MachineFunction *MF = BB->getParent();
@@ -37759,17 +37834,11 @@ static MachineBasicBlock *emitCTSelectI386WithFpType(MachineInstr &MI,
   MachineFrameInfo &MFI = MF->getFrameInfo();
   unsigned RegSizeInByte = 4;
 
-  // Get operands
-  // MI operands: %result:rfp80 = CTSELECT_I386 %false:rfp80, %true:rfp80, %cond:i8imm
+  // Get operands (pre-materialized condition byte at operand 3)
   unsigned DestReg = MI.getOperand(0).getReg();
   unsigned FalseReg = MI.getOperand(1).getReg();
   unsigned TrueReg = MI.getOperand(2).getReg();
-  X86::CondCode CC = static_cast<X86::CondCode>(MI.getOperand(3).getImm());
-  X86::CondCode OppCC = X86::GetOppositeBranchCondition(CC);
-
-  // Materialize condition byte from EFLAGS
-  Register CondByteReg = MRI.createVirtualRegister(&X86::GR8RegClass);
-  BuildMI(*BB, MI, MIMD, TII->get(X86::SETCCr), CondByteReg).addImm(OppCC);
+  Register CondByteReg = MI.getOperand(3).getReg();
 
   auto storeFpToSlot = [&](unsigned Opcode, int Slot, Register Reg) {
     addFrameReference(BuildMI(*BB, MI, MIMD, TII->get(Opcode)), Slot)
@@ -37858,7 +37927,7 @@ static MachineBasicBlock *emitCTSelectI386WithFpType(MachineInstr &MI,
   auto emitCtSelectWithPseudo = [&](unsigned NumValues, int TrueSlot, int FalseSlot, int ResultSlot) {
     for (unsigned Val = 0; Val < NumValues; ++Val) {
       unsigned Offset = Val * RegSizeInByte;
-      
+
       // Load true and false values from stack as 32-bit integers
       unsigned TrueIntReg = MRI.createVirtualRegister(&X86::GR32RegClass);
       BuildMI(*BB, MI, MIMD, TII->get(X86::MOV32rm), TrueIntReg)
@@ -37880,7 +37949,7 @@ static MachineBasicBlock *emitCTSelectI386WithFpType(MachineInstr &MI,
       unsigned ResultIntReg = MRI.createVirtualRegister(&X86::GR32RegClass);
       unsigned TmpByteReg = MRI.createVirtualRegister(&X86::GR8RegClass);
       unsigned TmpMaskReg = MRI.createVirtualRegister(&X86::GR32RegClass);
-      
+
       BuildMI(*BB, MI, MIMD, TII->get(X86::CTSELECT_I386_INT_GR32rr))
           .addDef(ResultIntReg)     // dst (output)
           .addDef(TmpByteReg)       // tmp_byte (output)
@@ -38032,7 +38101,7 @@ static MachineBasicBlock *emitCTSelectI386WithFpType(MachineInstr &MI,
     break;
   }
   default:
-    llvm_unreachable("Invalid CTSELECT opcode");
+    llvm_unreachable("Invalid CTSELECT_I386_BYTE opcode");
   }
 
   MI.eraseFromParent();
@@ -38113,13 +38182,25 @@ X86TargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
     return emitCTSelectI386WithConditionMaterialization(
         MI, BB, X86::CTSELECT_I386_INT_GR32rr);
 
+  case X86::CTSELECT_I386_BYTE_GR8rr:
+    return emitCTSelectI386WithByteCondition(
+        MI, BB, X86::CTSELECT_I386_INT_GR8rr);
+
+  case X86::CTSELECT_I386_BYTE_GR16rr:
+    return emitCTSelectI386WithByteCondition(
+        MI, BB, X86::CTSELECT_I386_INT_GR16rr);
+
+  case X86::CTSELECT_I386_BYTE_GR32rr:
+    return emitCTSelectI386WithByteCondition(
+        MI, BB, X86::CTSELECT_I386_INT_GR32rr);
+
   case X86::CTSELECT_I386_FP32rr:
     return emitCTSelectI386WithFpType(MI, BB, X86::CTSELECT_I386_FP32rr);
   case X86::CTSELECT_I386_FP64rr:
     return emitCTSelectI386WithFpType(MI, BB, X86::CTSELECT_I386_FP64rr);
   case X86::CTSELECT_I386_FP80rr:
     return emitCTSelectI386WithFpType(MI, BB, X86::CTSELECT_I386_FP80rr);
-    
+
   case X86::FP80_ADDr:
   case X86::FP80_ADDm32: {
     // Change the floating point control register to use double extended

--- a/llvm/lib/Target/X86/X86ISelLowering.h
+++ b/llvm/lib/Target/X86/X86ISelLowering.h
@@ -105,6 +105,13 @@ namespace llvm {
     /// used to implement constant-time select.
     CTSELECT,
 
+    /// X86 Constant-time Select for i386 with pre-materialized condition byte.
+    /// Operands: false_value, true_value, condition_byte (GR8)
+    /// This variant takes an i8 condition instead of EFLAGS to avoid sharing
+    /// EFLAGS across multiple ct_select operations where intervening code might
+    /// clobber flags.
+    CTSELECT_I386,
+
     // Same as SETCC except it's materialized with a sbb and the value is all
     // one's or all zero's.
     SETCC_CARRY, // R = carry_bit ? ~0 : 0

--- a/llvm/lib/Target/X86/X86InstrCompiler.td
+++ b/llvm/lib/Target/X86/X86InstrCompiler.td
@@ -726,6 +726,29 @@ let isCodeGenOnly = 1, hasSideEffects = 1, ForceDisassemble = 1 in {
   }
 }
 
+// Phase 1 pseudos with pre-materialized condition byte (no EFLAGS dependency)
+// These receive the condition as a GR8 register instead of EFLAGS, avoiding the
+// EFLAGS sharing issue that occurs when multiple ct_selects with same condition
+// are optimized and intervening code clobbers flags
+let isPseudo = 1, isNotDuplicable = 1 in {
+  class CTSELECT_I386_BYTE_INITIAL<RegisterClass RC, ValueType VT>
+      : PseudoI<(outs RC:$dst),
+                (ins RC:$src1, RC:$src2, GR8:$cond_byte),
+                [(set RC:$dst, (VT(X86ctselect_i386 RC:$src1, RC:$src2, GR8:$cond_byte)))]> {
+    // No Uses = [EFLAGS]!
+    let usesCustomInserter = 1;
+    let hasNoSchedulingInfo = 1;
+  }
+}
+
+let isCodeGenOnly = 1, hasSideEffects = 1, ForceDisassemble = 1 in {
+  let Predicates = [NoNativeCMOV] in {
+    def CTSELECT_I386_BYTE_GR8rr : CTSELECT_I386_BYTE_INITIAL<GR8, i8>;
+    def CTSELECT_I386_BYTE_GR16rr : CTSELECT_I386_BYTE_INITIAL<GR16, i16>;
+    def CTSELECT_I386_BYTE_GR32rr : CTSELECT_I386_BYTE_INITIAL<GR32, i32>;
+  }
+}
+
 // Phase 2 pseudos (post-RA expansion with pre-materialized condition byte)
 let isCodeGenOnly = 1, hasSideEffects = 1, ForceDisassemble = 1 in {
   let Predicates = [NoNativeCMOV] in {
@@ -738,17 +761,18 @@ let isCodeGenOnly = 1, hasSideEffects = 1, ForceDisassemble = 1 in {
   }
 }
 
+// Floating point types (take pre-materialized condition byte to avoid EFLAGS sharing)
 let hasSideEffects = 1,
     ForceDisassemble = 1,
     Constraints = "$dst = $src1" in {
 
   let Predicates = [FPStackf32] in
-    def CTSELECT_I386_FP32rr : CTSELECT_I386_INITIAL<RFP32, f32>;
+    def CTSELECT_I386_FP32rr : CTSELECT_I386_BYTE_INITIAL<RFP32, f32>;
 
   let Predicates = [FPStackf64] in
-    def CTSELECT_I386_FP64rr : CTSELECT_I386_INITIAL<RFP64, f64>;
+    def CTSELECT_I386_FP64rr : CTSELECT_I386_BYTE_INITIAL<RFP64, f64>;
 
-  def CTSELECT_I386_FP80rr : CTSELECT_I386_INITIAL<RFP80, f80>;
+  def CTSELECT_I386_FP80rr : CTSELECT_I386_BYTE_INITIAL<RFP80, f80>;
 }
 
 // Pattern matching for non-native-CMOV CTSELECT (routes to custom inserter for condition materialization)
@@ -766,6 +790,33 @@ let Predicates = [NoNativeCMOV] in {
 
   // i64 patterns handled automatically by type legalization
 }
+
+// Pattern matching for CTSELECT_I386 with pre-materialized condition byte
+// These patterns catch the new X86ISD::CTSELECT_I386 nodes created by LowerCTSELECT
+let Predicates = [NoNativeCMOV] in {
+  def : Pat<(i8(X86ctselect_i386 GR8:$src1, GR8:$src2, GR8:$cond_byte)),
+            (CTSELECT_I386_BYTE_GR8rr GR8:$src1, GR8:$src2, GR8:$cond_byte)>;
+
+  def : Pat<(i16(X86ctselect_i386 GR16:$src1, GR16:$src2, GR8:$cond_byte)),
+            (CTSELECT_I386_BYTE_GR16rr GR16:$src1, GR16:$src2, GR8:$cond_byte)>;
+
+  def : Pat<(i32(X86ctselect_i386 GR32:$src1, GR32:$src2, GR8:$cond_byte)),
+            (CTSELECT_I386_BYTE_GR32rr GR32:$src1, GR32:$src2, GR8:$cond_byte)>;
+
+  // i64 patterns handled automatically by type legalization
+}
+
+// Floating point patterns for CTSELECT_I386 with pre-materialized byte condition
+let Predicates = [FPStackf32] in
+  def : Pat<(f32(X86ctselect_i386 RFP32:$src1, RFP32:$src2, GR8:$cond_byte)),
+            (CTSELECT_I386_FP32rr RFP32:$src1, RFP32:$src2, GR8:$cond_byte)>;
+
+let Predicates = [FPStackf64] in
+  def : Pat<(f64(X86ctselect_i386 RFP64:$src1, RFP64:$src2, GR8:$cond_byte)),
+            (CTSELECT_I386_FP64rr RFP64:$src1, RFP64:$src2, GR8:$cond_byte)>;
+
+def : Pat<(f80(X86ctselect_i386 RFP80:$src1, RFP80:$src2, GR8:$cond_byte)),
+          (CTSELECT_I386_FP80rr RFP80:$src1, RFP80:$src2, GR8:$cond_byte)>;
 
 //===----------------------------------------------------------------------===//
 // Normal-Instructions-With-Lock-Prefix Pseudo Instructions

--- a/llvm/lib/Target/X86/X86InstrFragments.td
+++ b/llvm/lib/Target/X86/X86InstrFragments.td
@@ -32,6 +32,10 @@ def SDTX86CtSelect : SDTypeProfile<1, 4,
                                   [SDTCisSameAs<0, 1>, SDTCisSameAs<1, 2>,
                                    SDTCisVT<3, i8>, SDTCisVT<4, i32>]>;
 
+def SDTX86CtSelectI386 : SDTypeProfile<1, 3,
+                                  [SDTCisSameAs<0, 1>, SDTCisSameAs<1, 2>,
+                                   SDTCisVT<3, i8>]>;
+
 // Unary and binary operator instructions that set EFLAGS as a side-effect.
 def SDTUnaryArithWithFlags : SDTypeProfile<2, 1,
                                            [SDTCisSameAs<0, 2>,
@@ -156,6 +160,7 @@ def X86cload    : SDNode<"X86ISD::CLOAD",   SDTX86Cload, [SDNPHasChain, SDNPMayL
 def X86cstore   : SDNode<"X86ISD::CSTORE",  SDTX86Cstore, [SDNPHasChain, SDNPMayStore, SDNPMemOperand]>;
 
 def X86ctselect: SDNode<"X86ISD::CTSELECT", SDTX86CtSelect, [SDNPInGlue]>;
+def X86ctselect_i386: SDNode<"X86ISD::CTSELECT_I386", SDTX86CtSelectI386>;
 def X86cmov    : SDNode<"X86ISD::CMOV",     SDTX86Cmov>;
 def X86brcond  : SDNode<"X86ISD::BRCOND",   SDTX86BrCond,
                         [SDNPHasChain]>;


### PR DESCRIPTION
At -Oz optimization level, CSE shares a single TEST instruction across multiple __builtin_ct_select operations. However, the constant-time mask expansion uses NEG which clobbers EFLAGS between the shared TEST and subsequent SETCC instructions, causing later ct_selects to read stale flags and produce incorrect results.

Fix by materializing the condition to a byte register in SelectionDAG lowering instead of the custom inserter. Introduce X86ISD::CTSELECT_I386 node that takes a pre-materialized i8 condition instead of EFLAGS. Now CSE shares the safe-to-share byte value rather than EFLAGS, preventing the clobbering issue while still allowing optimization.

This change only affects i386 targets without CMOV support. Targets with CMOV continue using the existing EFLAGS-based path.